### PR TITLE
Release v1.1.8 - --continue-on-error for asset metadata create-batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.8] - 2026-04-21
+
+### Added
+- **`--continue-on-error` flag for `asset metadata create-batch`** - Allows the batch to skip rows whose asset path cannot be resolved and continue processing remaining rows. Mirrors the flag already available on `folder download`, `folder upload`, and `folder thumbnail` commands.
+  - Reuses the shared `continue_on_error_parameter()` helper in `commands::params` for consistency across commands
+  - Affects `pcli2 asset metadata create-batch` (and its `update-batch` alias)
+
+### Changed
+- **`asset metadata create-batch` default error behavior** - By default, any error (unresolvable asset path or failed metadata API call) now terminates the batch with a summary of successes and failures printed to stderr. Previously, asset-path lookup failures and metadata API errors were logged but the batch silently continued.
+  - Pass `--continue-on-error` to skip unresolvable asset paths and continue with the remaining rows
+  - Metadata API errors (delete/update) always terminate execution regardless of the flag, because the API layer already retries transient HTTP failures internally
+  - CSV parsing errors continue to terminate execution immediately, as before
+  - Authentication failures continue to terminate execution with a remediation message, as before
+  - Affects `pcli2 asset metadata create-batch` command
+
 ## [1.1.7] - 2026-04-13
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.1.7"
+version = "1.1.8"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ pcli2 folder download --folder-path "/Root/Folder/" --delay 2
 # Continue on errors
 pcli2 folder download --folder-path "/Root/Folder/" --continue-on-error
 
+# Continue past unresolvable asset paths in a metadata batch
+pcli2 asset metadata create-batch --csv-file "metadata.csv" --continue-on-error
+
 # Download thumbnails for all assets in a folder
 pcli2 folder thumbnail --folder-path "/Root/Folder/" --progress --concurrent 3
 ```
@@ -605,6 +608,10 @@ ASSET_PATH,NAME,VALUE
 - Empty rows will be ignored
 - Each row represents a single metadata field assignment for an asset
 - If an asset has multiple metadata fields to update, include multiple rows with the same `ASSET_PATH` but different `NAME` and `VALUE` combinations
+
+**Error Handling**:
+
+By default, the batch stops on the first error and reports how many assets were processed successfully. Pass `--continue-on-error` to skip rows whose `ASSET_PATH` cannot be resolved and continue with the remaining assets. Metadata API failures (e.g. a failed update for a resolved asset) always terminate the batch regardless of the flag, because the API layer already retries transient HTTP failures internally.
 
 ### Folder Commands
 

--- a/docs/src/metadata-operations.md
+++ b/docs/src/metadata-operations.md
@@ -157,18 +157,26 @@ PCLI2 supports three metadata field types:
 
 ## Error Handling
 
-The metadata operations are designed to be resilient:
-- Continues processing even if individual asset operations fail
-- Provides detailed error messages for troubleshooting
-- Automatically handles network failures with retries
-- Validates input formats before processing
+Metadata operations provide detailed error messages, retry transient network failures internally, and validate input formats before processing.
 
-Common error scenarios and their handling:
-- **Missing assets**: Command skips missing assets with appropriate warnings
-- **Network failures**: Individual operations retry, overall process continues
-- **Permission issues**: Skips inaccessible assets with warning messages
-- **Invalid metadata**: Logs error but continues processing other assets
-- **API rate limits**: Respects rate limits and waits before retrying
+### `create-batch` Error Behavior
+
+By default, `asset metadata create-batch` **stops on the first error** and prints a summary of how many assets were processed successfully. This makes failures visible instead of letting a batch silently complete with partial results.
+
+Specifically:
+
+- **CSV parsing errors**: always terminate immediately — the input file is expected to be well-formed
+- **Unresolvable asset paths** (asset not found): by default, terminates the batch. Pass `--continue-on-error` to skip the failing asset and continue with the remaining rows
+- **Metadata API failures** (delete/update): always terminate the batch, regardless of `--continue-on-error`. The API layer already retries transient HTTP failures, so a surfaced failure usually indicates a persistent problem (permissions, type conflict, etc.) that is likely to affect subsequent calls as well
+- **Authentication failures**: always terminate with a remediation message directing the user to re-authenticate
+
+**Example — skip unresolvable asset paths:**
+
+```bash
+pcli2 asset metadata create-batch --csv-file "metadata.csv" --continue-on-error
+```
+
+On completion (or termination), a summary is printed to stderr showing the number of successful and failed assets.
 
 ## Performance Considerations
 

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -501,8 +501,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                     break;
                 }
 
-                if error_str.contains("must be a") || error_str.contains("Metadata type mismatch")
-                {
+                if error_str.contains("must be a") || error_str.contains("Metadata type mismatch") {
                     error_utils::report_error_with_remediation(
                         &format!("Type conflict for asset '{}': {}", asset_path, e),
                         &[

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -7,8 +7,8 @@ use crate::{
     actions::folders::resolve_folder_uuid_by_path,
     actions::CliActionError,
     commands::params::{
-        PARAMETER_FILE, PARAMETER_FILES, PARAMETER_FOLDER_PATH, PARAMETER_FOLDER_UUID,
-        PARAMETER_PATH, PARAMETER_UUID,
+        PARAMETER_CONTINUE_ON_ERROR, PARAMETER_FILE, PARAMETER_FILES, PARAMETER_FOLDER_PATH,
+        PARAMETER_FOLDER_UUID, PARAMETER_PATH, PARAMETER_UUID,
     },
     configuration::Configuration,
     error::CliError,
@@ -262,6 +262,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
         .ok_or(CliError::MissingRequiredArgument("csv-file".to_string()))?;
 
     let show_progress = sub_matches.get_flag("progress");
+    let continue_on_error = sub_matches.get_flag(PARAMETER_CONTINUE_ON_ERROR);
 
     let configuration = Configuration::load_or_create_default()?;
     let mut api = PhysnaApiClient::try_default()?;
@@ -388,7 +389,19 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                             ]
                         );
                         failure_count += 1;
-                        continue;
+
+                        if continue_on_error {
+                            continue;
+                        }
+
+                        if show_progress {
+                            eprintln!();
+                        }
+                        eprintln!(
+                            "Batch operation stopped: {} successful, {} failed (use --continue-on-error to skip unresolvable asset paths)",
+                            success_count, failure_count
+                        );
+                        return Err(CliError::PhysnaExtendedApiError(e));
                     }
                 }
             }
@@ -406,8 +419,6 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                 typed_metadata.insert(field_name.clone(), json_value);
             }
         }
-
-        let mut asset_had_error = false;
 
         // Delete fields with empty values
         if !fields_to_delete.is_empty() {
@@ -447,12 +458,19 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                     ],
                 );
                 failure_count += 1;
-                asset_had_error = true;
+                if show_progress {
+                    eprintln!();
+                }
+                eprintln!(
+                    "Batch operation stopped: {} successful, {} failed",
+                    success_count, failure_count
+                );
+                return Err(CliError::PhysnaExtendedApiError(e));
             }
         }
 
         // Update fields with non-empty values
-        if !asset_had_error && !typed_metadata.is_empty() {
+        if !typed_metadata.is_empty() {
             if let Err(e) = api
                 .update_asset_metadata_with_registration(
                     &tenant.uuid,
@@ -463,18 +481,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
             {
                 let error_str = format!("{}", e);
 
-                if error_str.contains("must be a") || error_str.contains("Metadata type mismatch") {
-                    error_utils::report_error_with_remediation(
-                        &format!("Type conflict for asset '{}': {}", asset_path, e),
-                        &[
-                            "The metadata field already exists with a different type",
-                            "Delete the existing field first if you need to change its type",
-                            "Or provide a value that matches the existing field type",
-                        ],
-                    );
-                    failure_count += 1;
-                    asset_had_error = true;
-                } else if error_str.contains("Authentication")
+                if error_str.contains("Authentication")
                     || error_str.contains("unauthorized")
                     || error_str.contains("forbidden")
                 {
@@ -492,6 +499,18 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                     );
                     failure_count += 1;
                     break;
+                }
+
+                if error_str.contains("must be a") || error_str.contains("Metadata type mismatch")
+                {
+                    error_utils::report_error_with_remediation(
+                        &format!("Type conflict for asset '{}': {}", asset_path, e),
+                        &[
+                            "The metadata field already exists with a different type",
+                            "Delete the existing field first if you need to change its type",
+                            "Or provide a value that matches the existing field type",
+                        ],
+                    );
                 } else {
                     error_utils::report_error_with_remediation(
                         &format!(
@@ -505,15 +524,20 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                             "Confirm the asset hasn't been deleted or modified recently",
                         ],
                     );
-                    failure_count += 1;
-                    asset_had_error = true;
                 }
+                failure_count += 1;
+                if show_progress {
+                    eprintln!();
+                }
+                eprintln!(
+                    "Batch operation stopped: {} successful, {} failed",
+                    success_count, failure_count
+                );
+                return Err(CliError::PhysnaExtendedApiError(e));
             }
         }
 
-        if !asset_had_error {
-            success_count += 1;
-        }
+        success_count += 1;
     }
 
     if show_progress {

--- a/src/commands/metadata.rs
+++ b/src/commands/metadata.rs
@@ -3,9 +3,10 @@
 //! This module defines CLI commands related to asset metadata management.
 
 use crate::commands::params::{
-    format_parameter, format_pretty_parameter, format_with_headers_parameter,
-    format_with_metadata_parameter, path_parameter, tenant_parameter, uuid_parameter,
-    COMMAND_CREATE, COMMAND_DELETE, COMMAND_GET, COMMAND_METADATA,
+    continue_on_error_parameter, format_parameter, format_pretty_parameter,
+    format_with_headers_parameter, format_with_metadata_parameter, path_parameter,
+    tenant_parameter, uuid_parameter, COMMAND_CREATE, COMMAND_DELETE, COMMAND_GET,
+    COMMAND_METADATA,
 };
 use clap::{Arg, ArgAction, ArgGroup, Command};
 
@@ -119,7 +120,13 @@ pub fn metadata_command() -> Command {
                     folder/subfolder/asset1.stl,Weight,\"15.5 kg\"\n\
                     folder/subfolder/asset2.ipt,Material,Aluminum\n\n\
                     The command will group metadata by asset path and update all metadata \
-                    for each asset in a single API call."
+                    for each asset in a single API call.\n\n\
+                    By default, any error (such as an asset path that cannot be resolved \
+                    or a failed metadata API call) terminates the batch operation. \
+                    Pass --continue-on-error to skip assets whose paths cannot be resolved \
+                    and continue with the remaining rows. Metadata API errors always \
+                    terminate execution regardless of this flag, because the API already \
+                    retries transient failures internally."
                 )
                 .arg(tenant_parameter())
                 .arg(
@@ -136,7 +143,8 @@ pub fn metadata_command() -> Command {
                         .action(ArgAction::SetTrue)
                         .required(false)
                         .help("Display progress bar during processing"),
-                ),
+                )
+                .arg(continue_on_error_parameter()),
         )
         .subcommand(
             Command::new("inference")

--- a/src/commands/params.rs
+++ b/src/commands/params.rs
@@ -413,7 +413,7 @@ pub fn continue_on_error_parameter() -> Arg {
         .long(PARAMETER_CONTINUE_ON_ERROR)
         .action(ArgAction::SetTrue)
         .required(false)
-        .help("Continue downloading other assets if one fails")
+        .help("Continue processing remaining items when a recoverable error occurs")
 }
 
 /// Create the delay parameter.

--- a/src/path_utils.rs
+++ b/src/path_utils.rs
@@ -38,7 +38,7 @@ pub fn find_similar_paths(hierarchy: &FolderHierarchy, target_path: &str) -> Vec
     }
 
     // Sort by similarity (highest first) and return top suggestions
-    suggestions.sort_by(|a, b| b.1.cmp(&a.1));
+    suggestions.sort_by_key(|s| std::cmp::Reverse(s.1));
     suggestions
         .into_iter()
         .take(3)

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -3826,26 +3826,24 @@ impl PhysnaApiClient {
                 Err(e) => {
                     // If we get a 404, it might mean there are no assets with that state
                     match &e {
-                        ApiError::HttpError(reqwest_err) => {
-                            if reqwest_err.status() == Some(reqwest::StatusCode::NOT_FOUND) {
-                                debug!(
-                                    "No assets found with state: {} for tenant: {}",
-                                    state, tenant_uuid
-                                );
-                                // Return an empty response instead of an error
-                                AssetListResponse {
-                                    assets: vec![],
-                                    page_data: crate::model::PageData {
-                                        current_page: page,
-                                        per_page,
-                                        total: 0,
-                                        last_page: 1,
-                                        start_index: 0,
-                                        end_index: 0,
-                                    },
-                                }
-                            } else {
-                                return Err(e);
+                        ApiError::HttpError(reqwest_err)
+                            if reqwest_err.status() == Some(reqwest::StatusCode::NOT_FOUND) =>
+                        {
+                            debug!(
+                                "No assets found with state: {} for tenant: {}",
+                                state, tenant_uuid
+                            );
+                            // Return an empty response instead of an error
+                            AssetListResponse {
+                                assets: vec![],
+                                page_data: crate::model::PageData {
+                                    current_page: page,
+                                    per_page,
+                                    total: 0,
+                                    last_page: 1,
+                                    start_index: 0,
+                                    end_index: 0,
+                                },
                             }
                         }
                         _ => return Err(e),


### PR DESCRIPTION
## Summary

Release v1.1.8.

- New `--continue-on-error` flag on `asset metadata create-batch` — skip rows whose ASSET_PATH cannot be resolved and continue processing remaining rows
- Reuses the shared `continue_on_error_parameter()` helper (first non-folder command to consume it)
- Tightened default error behavior: unresolvable paths and metadata API failures now terminate the batch with a stderr summary; previously the batch silently continued. Metadata API errors always terminate regardless of the flag
- CHANGELOG, README, mdbook docs updated; `Cargo.toml` bumped to `1.1.8`

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets` (no new warnings)
- [x] `cargo test --test cli_help_test --test asset_tests --test actions_tests`
- [x] Release `plan` dry-run passed on feature PR [#24](https://github.com/jchultarsky101/pcli2/pull/24)
- [ ] Rust CI passes on this PR
- [ ] Release workflow succeeds after tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)