### PR TITLE
fix: resolve clippy lints for Rust 1.95.0

### DIFF
--- a/src/path_utils.rs
+++ b/src/path_utils.rs
@@ -38,7 +38,7 @@ pub fn find_similar_paths(hierarchy: &FolderHierarchy, target_path: &str) -> Vec
     }
 
     // Sort by similarity (highest first) and return top suggestions
-    suggestions.sort_by(|a, b| b.1.cmp(&a.1));
+    suggestions.sort_by_key(|s| std::cmp::Reverse(s.1));
     suggestions
         .into_iter()
         .take(3)

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -3826,26 +3826,24 @@ impl PhysnaApiClient {
                 Err(e) => {
                     // If we get a 404, it might mean there are no assets with that state
                     match &e {
-                        ApiError::HttpError(reqwest_err) => {
-                            if reqwest_err.status() == Some(reqwest::StatusCode::NOT_FOUND) {
-                                debug!(
-                                    "No assets found with state: {} for tenant: {}",
-                                    state, tenant_uuid
-                                );
-                                // Return an empty response instead of an error
-                                AssetListResponse {
-                                    assets: vec![],
-                                    page_data: crate::model::PageData {
-                                        current_page: page,
-                                        per_page,
-                                        total: 0,
-                                        last_page: 1,
-                                        start_index: 0,
-                                        end_index: 0,
-                                    },
-                                }
-                            } else {
-                                return Err(e);
+                        ApiError::HttpError(reqwest_err)
+                            if reqwest_err.status() == Some(reqwest::StatusCode::NOT_FOUND) =>
+                        {
+                            debug!(
+                                "No assets found with state: {} for tenant: {}",
+                                state, tenant_uuid
+                            );
+                            // Return an empty response instead of an error
+                            AssetListResponse {
+                                assets: vec![],
+                                page_data: crate::model::PageData {
+                                    current_page: page,
+                                    per_page,
+                                    total: 0,
+                                    last_page: 1,
+                                    start_index: 0,
+                                    end_index: 0,
+                                },
                             }
                         }
                         _ => return Err(e),


### PR DESCRIPTION
Rust 1.95.0 promotes two lints from allow to warn, which the CI treats as errors via `-D warnings`:

- `unnecessary_sort_by` in `src/path_utils.rs:41` — use `sort_by_key(|s| std::cmp::Reverse(s.1))`
- `collapsible_match` in `src/physna_v3.rs:3830` — collapse the nested `if` into the outer `match` arm guard

Blocks the v1.1.8 release PR [#25](https://github.com/jchultarsky101/pcli2/pull/25). Applying the clippy auto-suggested fixes mechanically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)