### PR TITLE
Release v1.1.9 - --override for asset create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.9] - 2026-05-07
+
+### Added
+- **`--override` flag for `asset create`** - When uploading an asset that already exists at the target path, automatically delete the existing asset and re-upload the new version in its place. Without this flag, the command continues to fail with a conflict error as before.
+  - Only triggers on HTTP 409 (asset already exists); other errors are unaffected
+  - Affects `pcli2 asset create` (and its `upload` alias)
+
 ## [1.1.8] - 2026-04-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.1.8"
+version = "1.1.9"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.1.8"
+version = "1.1.9"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -8,7 +8,7 @@ use crate::{
     actions::CliActionError,
     commands::params::{
         PARAMETER_CONTINUE_ON_ERROR, PARAMETER_FILE, PARAMETER_FILES, PARAMETER_FOLDER_PATH,
-        PARAMETER_FOLDER_UUID, PARAMETER_PATH, PARAMETER_UUID,
+        PARAMETER_FOLDER_UUID, PARAMETER_OVERRIDE, PARAMETER_PATH, PARAMETER_UUID,
     },
     configuration::Configuration,
     error::CliError,
@@ -19,7 +19,7 @@ use crate::{
     model::{Asset, AssetList},
     param_utils::get_format_parameter_value,
     param_utils::get_tenant,
-    physna_v3::{PhysnaApiClient, TryDefault},
+    physna_v3::{ApiError, PhysnaApiClient, TryDefault},
 };
 use clap::ArgMatches;
 use serde_json::Value;
@@ -155,9 +155,32 @@ pub async fn create_asset(sub_matches: &ArgMatches) -> Result<(), CliError> {
 
     debug!("Creating asset with path: {}", asset_path);
 
-    let asset = api
+    let override_flag = sub_matches.get_flag(PARAMETER_OVERRIDE);
+
+    let asset = match api
         .create_asset(&tenant.uuid, file_path, &asset_path, &folder_uuid)
-        .await?;
+        .await
+    {
+        Ok(asset) => asset,
+        Err(ApiError::ConflictError(ref msg))
+            if override_flag && msg.contains("Asset already exists") =>
+        {
+            debug!(
+                "Asset already exists at path '{}', --override specified, deleting and re-uploading",
+                asset_path
+            );
+            let existing = api.get_asset_by_path(&tenant.uuid, &asset_path).await?;
+            api.delete_asset(
+                &tenant.uuid.to_string(),
+                &existing.uuid().to_string(),
+            )
+            .await?;
+            api.create_asset(&tenant.uuid, file_path, &asset_path, &folder_uuid)
+                .await?
+        }
+        Err(e) => return Err(e.into()),
+    };
+
     println!("{}", asset.format(format)?);
 
     Ok(())

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -170,11 +170,8 @@ pub async fn create_asset(sub_matches: &ArgMatches) -> Result<(), CliError> {
                 asset_path
             );
             let existing = api.get_asset_by_path(&tenant.uuid, &asset_path).await?;
-            api.delete_asset(
-                &tenant.uuid.to_string(),
-                &existing.uuid().to_string(),
-            )
-            .await?;
+            api.delete_asset(&tenant.uuid.to_string(), &existing.uuid().to_string())
+                .await?;
             api.create_asset(&tenant.uuid, file_path, &asset_path, &folder_uuid)
                 .await?
         }

--- a/src/commands/assets.rs
+++ b/src/commands/assets.rs
@@ -8,11 +8,12 @@ use crate::commands::params::{
     asset_identifier_group, asset_identifier_multiple_group, file_parameter,
     folder_identifier_group, folder_path_parameter, folder_uuid_parameter, format_parameter,
     format_pretty_parameter, format_with_headers_parameter, format_with_metadata_parameter,
-    multiple_files_parameter, path_parameter, tenant_parameter, uuid_parameter, COMMAND_ASSET,
-    COMMAND_CREATE, COMMAND_CREATE_BATCH, COMMAND_DELETE, COMMAND_DEPENDENCIES, COMMAND_DOWNLOAD,
-    COMMAND_GET, COMMAND_LIST, COMMAND_MATCH, COMMAND_PART_MATCH, COMMAND_REPROCESS,
-    COMMAND_TEXT_MATCH, COMMAND_THUMBNAIL, COMMAND_VISUAL_MATCH, FORMAT_CSV, FORMAT_JSON,
-    FORMAT_TREE, PARAMETER_CONCURRENT, PARAMETER_FILE, PARAMETER_FUZZY, PARAMETER_PROGRESS,
+    multiple_files_parameter, override_parameter, path_parameter, tenant_parameter, uuid_parameter,
+    COMMAND_ASSET, COMMAND_CREATE, COMMAND_CREATE_BATCH, COMMAND_DELETE, COMMAND_DEPENDENCIES,
+    COMMAND_DOWNLOAD, COMMAND_GET, COMMAND_LIST, COMMAND_MATCH, COMMAND_PART_MATCH,
+    COMMAND_REPROCESS, COMMAND_TEXT_MATCH, COMMAND_THUMBNAIL, COMMAND_VISUAL_MATCH, FORMAT_CSV,
+    FORMAT_JSON, FORMAT_TREE, PARAMETER_CONCURRENT, PARAMETER_FILE, PARAMETER_FUZZY,
+    PARAMETER_PROGRESS,
 };
 use clap::{Arg, ArgAction, Command};
 
@@ -46,7 +47,8 @@ pub fn asset_command() -> Command {
                 .arg(format_with_metadata_parameter())
                 .arg(format_with_headers_parameter())
                 .arg(format_pretty_parameter())
-                .arg(format_parameter().value_parser([FORMAT_JSON, FORMAT_CSV])),
+                .arg(format_parameter().value_parser([FORMAT_JSON, FORMAT_CSV]))
+                .arg(override_parameter()),
         )
         .subcommand(
             Command::new(COMMAND_CREATE_BATCH)

--- a/src/commands/params.rs
+++ b/src/commands/params.rs
@@ -107,6 +107,7 @@ pub const PARAMETER_DELAY: &str = "delay";
 pub const PARAMETER_LOCAL_PATH: &str = "local-path";
 pub const PARAMETER_SKIP_EXISTING: &str = "skip-existing";
 pub const PARAMETER_RESUME: &str = "resume";
+pub const PARAMETER_OVERRIDE: &str = "override";
 
 // Format options
 pub const FORMAT_CSV: &str = "csv";
@@ -431,6 +432,15 @@ pub fn delay_parameter() -> Arg {
                 Ok(val)
             }
         })
+}
+
+/// Create the override parameter for asset create commands.
+pub fn override_parameter() -> Arg {
+    Arg::new(PARAMETER_OVERRIDE)
+        .long(PARAMETER_OVERRIDE)
+        .action(ArgAction::SetTrue)
+        .required(false)
+        .help("If the asset already exists, delete it and upload the new version in its place")
 }
 
 /// Create the resume parameter.


### PR DESCRIPTION
## Summary
- Adds `--override` flag to `asset create` command: when an asset already exists at the target path, automatically deletes the existing asset and re-uploads the new version in its place
- Bumps version to 1.1.9

## Test plan
- [ ] `pcli2 asset create --file test.stl --folder-path /Test` (normal upload, no override)
- [ ] `pcli2 asset create --file test.stl --folder-path /Test --override` (upload when asset already exists — should delete and re-upload)
- [ ] `pcli2 asset create --file test.stl --folder-path /Test` (upload when asset already exists, no override — should fail with conflict error)
- [ ] Verify `--override` appears in `pcli2 asset create --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)