### PR TITLE
Release v1.1.10 - --override and --restore-metadata for asset create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.9] - 2026-05-07
+## [1.1.10] - 2026-05-07
 
 ### Added
-- **`--override` flag for `asset create`** - When uploading an asset that already exists at the target path, automatically delete the existing asset and re-upload the new version in its place. Without this flag, the command continues to fail with a conflict error as before.
-  - Only triggers on HTTP 409 (asset already exists); other errors are unaffected
+- **`--override` flag for `asset create`** - When uploading an asset that already exists at the target path, automatically delete the existing asset and re-upload the new version in its place. Without this flag, a duplicate asset is created at the same path.
+  - Proactively checks for an existing asset before uploading; if found, deletes it first
+  - Affects `pcli2 asset create` (and its `upload` alias)
+- **`--restore-metadata` flag for `asset create`** - When used together with `--override`, preserves the existing asset's metadata and applies it to the newly uploaded asset. The metadata is passed directly in the upload request for a single-operation restore.
+  - Requires `--override` (enforced by the CLI parser)
+  - If the existing asset has no metadata, the flag is silently ignored
   - Affects `pcli2 asset create` (and its `upload` alias)
 
 ## [1.1.8] - 2026-04-21

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.1.9"
+version = "1.1.10"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/README.md
+++ b/README.md
@@ -235,7 +235,13 @@ Upload, download, and manage assets:
 
 ```bash
 # Upload a single asset
-pcli2 asset create --file path/to/model.stl --path "/Root/Models/"
+pcli2 asset create --file path/to/model.stl --folder-path "/Root/Models/"
+
+# Replace an existing asset (delete + re-upload)
+pcli2 asset create --file path/to/model.stl --folder-path "/Root/Models/" --override
+
+# Replace an existing asset and preserve its metadata
+pcli2 asset create --file path/to/model.stl --folder-path "/Root/Models/" --override --restore-metadata
 
 # List assets in a folder
 pcli2 asset list --path "/Root/Models/" --format json

--- a/SLACK_ANNOUNCEMENT_v1.1.10.md
+++ b/SLACK_ANNOUNCEMENT_v1.1.10.md
@@ -1,0 +1,87 @@
+# 🚀 Release Announcement: pcli2 v1.1.10
+
+**Date:** May 7, 2026
+**Version:** v1.1.10
+
+---
+
+## 📋 What's New
+
+This release adds two new flags to the `asset create` command for seamless asset replacement with optional metadata preservation.
+
+---
+
+## ✨ New Features
+
+### `--override` Flag for `asset create`
+
+**Problem:** Re-uploading an asset to a path where one already exists creates a duplicate — two assets with different UUIDs at the same path. Previously, users had to manually find and delete the existing asset before uploading.
+
+**Solution:** The `--override` flag handles this automatically:
+
+```bash
+# Replace an existing asset in one step
+pcli2 asset create --file part.stl --folder-path /MyFolder --override
+```
+
+- ✅ Checks if an asset already exists at the target path before uploading
+- ✅ If found, deletes the existing asset and uploads the new version
+- ✅ If no existing asset, uploads normally
+- ✅ Without `--override`, behavior is unchanged
+
+---
+
+### `--restore-metadata` Flag for `asset create`
+
+**Problem:** When replacing an asset with `--override`, the old asset's metadata is lost because the asset is deleted and a new one is created.
+
+**Solution:** The `--restore-metadata` flag preserves metadata through the replacement:
+
+```bash
+# Replace an asset and keep its metadata
+pcli2 asset create --file part.stl --folder-path /MyFolder --override --restore-metadata
+```
+
+- ✅ Reads metadata from the existing asset before deletion
+- ✅ Passes metadata directly in the upload request (single API call)
+- ✅ Requires `--override` (enforced by CLI parser)
+- ✅ Silently ignored if the existing asset has no metadata
+
+---
+
+## 📦 How to Update
+
+### Homebrew (recommended)
+```bash
+brew update
+brew upgrade pcli2
+```
+
+### Cargo
+```bash
+cargo install --git https://github.com/jchultarsky101/pcli2.git --tag v1.1.10
+```
+
+### Docker
+```bash
+docker pull ghcr.io/jchultarsky101/pcli2:v1.1.10
+```
+
+---
+
+## 🔗 Links
+
+- **Release Notes:** https://github.com/jchultarsky101/pcli2/releases/tag/v1.1.10
+- **Full Changelog:** https://github.com/jchultarsky101/pcli2/blob/main/CHANGELOG.md
+- **Documentation:** https://github.com/jchultarsky101/pcli2/blob/main/README.md
+
+---
+
+## 🙏 Reporting Issues
+
+Found a bug or have feedback? Please report it at:
+https://github.com/jchultarsky101/pcli2/issues
+
+---
+
+**Happy querying! 🎉**

--- a/SLACK_ANNOUNCEMENT_v1.1.9.md
+++ b/SLACK_ANNOUNCEMENT_v1.1.9.md
@@ -1,0 +1,73 @@
+# 🚀 Release Announcement: pcli2 v1.1.9
+
+**Date:** May 7, 2026
+**Version:** v1.1.9
+
+---
+
+## 📋 What's New
+
+This release adds a new **`--override`** flag to the `asset create` command, enabling seamless re-upload of assets that already exist at the target path.
+
+---
+
+## ✨ New Feature
+
+### `--override` Flag for `asset create`
+
+**Problem:** When uploading an asset to a path where an asset already exists, the API returns a conflict error. Previously, users had to manually delete the existing asset and then re-upload — a two-step process that's tedious in scripted workflows.
+
+**Solution:** The new `--override` flag automates this:
+
+```bash
+# Upload normally (fails if asset exists)
+pcli2 asset create --file part.stl --folder-path /MyFolder
+
+# Automatically replace existing asset
+pcli2 asset create --file part.stl --folder-path /MyFolder --override
+```
+
+**How it works:**
+- ✅ Attempts the upload as normal
+- ✅ If the asset already exists (HTTP 409) and `--override` is set, deletes the existing asset and re-uploads
+- ✅ Without `--override`, behavior is unchanged — conflict errors are reported as before
+- ✅ Other errors (file too large, unsupported type, etc.) are unaffected by the flag
+
+---
+
+## 📦 How to Update
+
+### Homebrew (recommended)
+```bash
+brew update
+brew upgrade pcli2
+```
+
+### Cargo
+```bash
+cargo install --git https://github.com/jchultarsky101/pcli2.git --tag v1.1.9
+```
+
+### Docker
+```bash
+docker pull ghcr.io/jchultarsky101/pcli2:v1.1.9
+```
+
+---
+
+## 🔗 Links
+
+- **Release Notes:** https://github.com/jchultarsky101/pcli2/releases/tag/v1.1.9
+- **Full Changelog:** https://github.com/jchultarsky101/pcli2/blob/main/CHANGELOG.md
+- **Documentation:** https://github.com/jchultarsky101/pcli2/blob/main/README.md
+
+---
+
+## 🙏 Reporting Issues
+
+Found a bug or have feedback? Please report it at:
+https://github.com/jchultarsky101/pcli2/issues
+
+---
+
+**Happy querying! 🎉**

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -81,7 +81,13 @@ The `asset create` command uploads individual files to your Physna tenant, placi
 
 ```bash
 # Upload a single asset
-pcli2 asset create --file path/to/my/model.stl --path /Root/MyFolder/
+pcli2 asset create --file path/to/my/model.stl --folder-path /Root/MyFolder/
+
+# Replace an existing asset (deletes the old one first)
+pcli2 asset create --file path/to/my/model.stl --folder-path /Root/MyFolder/ --override
+
+# Replace an existing asset and keep its metadata
+pcli2 asset create --file path/to/my/model.stl --folder-path /Root/MyFolder/ --override --restore-metadata
 ```
 
 For bulk operations, `asset create-batch` allows you to upload multiple files at once using glob patterns:

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -8,7 +8,8 @@ use crate::{
     actions::CliActionError,
     commands::params::{
         PARAMETER_CONTINUE_ON_ERROR, PARAMETER_FILE, PARAMETER_FILES, PARAMETER_FOLDER_PATH,
-        PARAMETER_FOLDER_UUID, PARAMETER_OVERRIDE, PARAMETER_PATH, PARAMETER_UUID,
+        PARAMETER_FOLDER_UUID, PARAMETER_OVERRIDE, PARAMETER_PATH, PARAMETER_RESTORE_METADATA,
+        PARAMETER_UUID,
     },
     configuration::Configuration,
     error::CliError,
@@ -156,6 +157,7 @@ pub async fn create_asset(sub_matches: &ArgMatches) -> Result<(), CliError> {
     debug!("Creating asset with path: {}", asset_path);
 
     let override_flag = sub_matches.get_flag(PARAMETER_OVERRIDE);
+    let restore_metadata = sub_matches.get_flag(PARAMETER_RESTORE_METADATA);
 
     let asset = match api
         .create_asset(&tenant.uuid, file_path, &asset_path, &folder_uuid)
@@ -170,10 +172,43 @@ pub async fn create_asset(sub_matches: &ArgMatches) -> Result<(), CliError> {
                 asset_path
             );
             let existing = api.get_asset_by_path(&tenant.uuid, &asset_path).await?;
+
+            let saved_metadata = if restore_metadata {
+                let full_asset = api
+                    .get_asset_by_uuid(&tenant.uuid, &existing.uuid())
+                    .await?;
+                let metadata: HashMap<String, serde_json::Value> = full_asset
+                    .metadata()
+                    .map(|m| {
+                        m.keys()
+                            .filter_map(|k| {
+                                m.get(k)
+                                    .map(|v| (k.clone(), serde_json::Value::String(v.clone())))
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                if metadata.is_empty() {
+                    debug!("No metadata found on existing asset to restore");
+                    None
+                } else {
+                    debug!("Saved {} metadata fields for restoration", metadata.len());
+                    Some(metadata)
+                }
+            } else {
+                None
+            };
+
             api.delete_asset(&tenant.uuid.to_string(), &existing.uuid().to_string())
                 .await?;
-            api.create_asset(&tenant.uuid, file_path, &asset_path, &folder_uuid)
-                .await?
+            api.create_asset_with_metadata(
+                &tenant.uuid,
+                file_path,
+                &asset_path,
+                &folder_uuid,
+                saved_metadata.as_ref(),
+            )
+            .await?
         }
         Err(e) => return Err(e.into()),
     };

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -20,7 +20,7 @@ use crate::{
     model::{Asset, AssetList},
     param_utils::get_format_parameter_value,
     param_utils::get_tenant,
-    physna_v3::{ApiError, PhysnaApiClient, TryDefault},
+    physna_v3::{PhysnaApiClient, TryDefault},
 };
 use clap::ArgMatches;
 use serde_json::Value;
@@ -159,25 +159,17 @@ pub async fn create_asset(sub_matches: &ArgMatches) -> Result<(), CliError> {
     let override_flag = sub_matches.get_flag(PARAMETER_OVERRIDE);
     let restore_metadata = sub_matches.get_flag(PARAMETER_RESTORE_METADATA);
 
-    let asset = match api
-        .create_asset(&tenant.uuid, file_path, &asset_path, &folder_uuid)
-        .await
-    {
-        Ok(asset) => asset,
-        Err(ApiError::ConflictError(ref msg))
-            if override_flag && msg.contains("Asset already exists") =>
-        {
+    let asset = if override_flag {
+        let existing = api.get_asset_by_path(&tenant.uuid, &asset_path).await.ok();
+
+        if let Some(existing) = existing {
             debug!(
                 "Asset already exists at path '{}', --override specified, deleting and re-uploading",
                 asset_path
             );
-            let existing = api.get_asset_by_path(&tenant.uuid, &asset_path).await?;
 
             let saved_metadata = if restore_metadata {
-                let full_asset = api
-                    .get_asset_by_uuid(&tenant.uuid, &existing.uuid())
-                    .await?;
-                let metadata: HashMap<String, serde_json::Value> = full_asset
+                let metadata: HashMap<String, serde_json::Value> = existing
                     .metadata()
                     .map(|m| {
                         m.keys()
@@ -209,8 +201,13 @@ pub async fn create_asset(sub_matches: &ArgMatches) -> Result<(), CliError> {
                 saved_metadata.as_ref(),
             )
             .await?
+        } else {
+            api.create_asset(&tenant.uuid, file_path, &asset_path, &folder_uuid)
+                .await?
         }
-        Err(e) => return Err(e.into()),
+    } else {
+        api.create_asset(&tenant.uuid, file_path, &asset_path, &folder_uuid)
+            .await?
     };
 
     println!("{}", asset.format(format)?);

--- a/src/commands/assets.rs
+++ b/src/commands/assets.rs
@@ -8,12 +8,12 @@ use crate::commands::params::{
     asset_identifier_group, asset_identifier_multiple_group, file_parameter,
     folder_identifier_group, folder_path_parameter, folder_uuid_parameter, format_parameter,
     format_pretty_parameter, format_with_headers_parameter, format_with_metadata_parameter,
-    multiple_files_parameter, override_parameter, path_parameter, tenant_parameter, uuid_parameter,
-    COMMAND_ASSET, COMMAND_CREATE, COMMAND_CREATE_BATCH, COMMAND_DELETE, COMMAND_DEPENDENCIES,
-    COMMAND_DOWNLOAD, COMMAND_GET, COMMAND_LIST, COMMAND_MATCH, COMMAND_PART_MATCH,
-    COMMAND_REPROCESS, COMMAND_TEXT_MATCH, COMMAND_THUMBNAIL, COMMAND_VISUAL_MATCH, FORMAT_CSV,
-    FORMAT_JSON, FORMAT_TREE, PARAMETER_CONCURRENT, PARAMETER_FILE, PARAMETER_FUZZY,
-    PARAMETER_PROGRESS,
+    multiple_files_parameter, override_parameter, path_parameter, restore_metadata_parameter,
+    tenant_parameter, uuid_parameter, COMMAND_ASSET, COMMAND_CREATE, COMMAND_CREATE_BATCH,
+    COMMAND_DELETE, COMMAND_DEPENDENCIES, COMMAND_DOWNLOAD, COMMAND_GET, COMMAND_LIST,
+    COMMAND_MATCH, COMMAND_PART_MATCH, COMMAND_REPROCESS, COMMAND_TEXT_MATCH, COMMAND_THUMBNAIL,
+    COMMAND_VISUAL_MATCH, FORMAT_CSV, FORMAT_JSON, FORMAT_TREE, PARAMETER_CONCURRENT,
+    PARAMETER_FILE, PARAMETER_FUZZY, PARAMETER_PROGRESS,
 };
 use clap::{Arg, ArgAction, Command};
 
@@ -48,7 +48,8 @@ pub fn asset_command() -> Command {
                 .arg(format_with_headers_parameter())
                 .arg(format_pretty_parameter())
                 .arg(format_parameter().value_parser([FORMAT_JSON, FORMAT_CSV]))
-                .arg(override_parameter()),
+                .arg(override_parameter())
+                .arg(restore_metadata_parameter()),
         )
         .subcommand(
             Command::new(COMMAND_CREATE_BATCH)

--- a/src/commands/params.rs
+++ b/src/commands/params.rs
@@ -108,6 +108,7 @@ pub const PARAMETER_LOCAL_PATH: &str = "local-path";
 pub const PARAMETER_SKIP_EXISTING: &str = "skip-existing";
 pub const PARAMETER_RESUME: &str = "resume";
 pub const PARAMETER_OVERRIDE: &str = "override";
+pub const PARAMETER_RESTORE_METADATA: &str = "restore-metadata";
 
 // Format options
 pub const FORMAT_CSV: &str = "csv";
@@ -441,6 +442,16 @@ pub fn override_parameter() -> Arg {
         .action(ArgAction::SetTrue)
         .required(false)
         .help("If the asset already exists, delete it and upload the new version in its place")
+}
+
+/// Create the restore-metadata parameter for asset create commands.
+pub fn restore_metadata_parameter() -> Arg {
+    Arg::new(PARAMETER_RESTORE_METADATA)
+        .long(PARAMETER_RESTORE_METADATA)
+        .action(ArgAction::SetTrue)
+        .required(false)
+        .requires(PARAMETER_OVERRIDE)
+        .help("When used with --override, preserve the existing asset's metadata and apply it to the new asset")
 }
 
 /// Create the resume parameter.

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -2335,6 +2335,18 @@ impl PhysnaApiClient {
         asset_path: &String,
         folder_uuid: &Uuid,
     ) -> Result<crate::model::Asset, ApiError> {
+        self.create_asset_with_metadata(tenant_uuid, file_path, asset_path, folder_uuid, None)
+            .await
+    }
+
+    pub async fn create_asset_with_metadata(
+        &mut self,
+        tenant_uuid: &Uuid,
+        file_path: &Path,
+        asset_path: &String,
+        folder_uuid: &Uuid,
+        metadata: Option<&std::collections::HashMap<String, serde_json::Value>>,
+    ) -> Result<crate::model::Asset, ApiError> {
         trace!("Creating new asset by uploading a file...");
 
         let url = format!("{}/tenants/{}/assets", self.base_url, tenant_uuid);
@@ -2350,6 +2362,10 @@ impl PhysnaApiClient {
             .unwrap()
             .to_string_lossy()
             .into_owned(); // It is save to unwrap because we already confired the file exists
+
+        let metadata_json = metadata
+            .map(|m| serde_json::to_string(m).unwrap_or_default())
+            .unwrap_or_default();
 
         trace!(
             "Uploading file: {}, with full path: {}",
@@ -2375,7 +2391,7 @@ impl PhysnaApiClient {
         let form = reqwest::multipart::Form::new()
             .part("file", file_part)
             .text("path", asset_path.clone()) // Full asset path including folder structure
-            .text("metadata", "") // Empty metadata
+            .text("metadata", metadata_json.clone())
             .text("createMissingFolders", "true"); // Enable creating missing folders
 
         debug!("Creating asset with path: {}", asset_path);
@@ -2425,7 +2441,7 @@ impl PhysnaApiClient {
             let mut retry_form = reqwest::multipart::Form::new()
                 .part("file", retry_file_part)
                 .text("path", asset_path.clone()) // Use the full asset path including folder
-                .text("metadata", "") // Empty metadata as in the working example
+                .text("metadata", metadata_json.clone())
                 .text("createMissingFolders", ""); // Empty createMissingFolders as in the working example
 
             // Add folder ID if provided


### PR DESCRIPTION
## Summary
- Adds `--override` flag to `asset create`: proactively checks if an asset exists at the target path and deletes it before uploading, preventing duplicates
- Adds `--restore-metadata` flag (requires `--override`): preserves the existing asset's metadata and passes it in the upload request so the new asset inherits it
- Adds `create_asset_with_metadata` API method that accepts optional metadata in the multipart upload form
- Updates README, quickstart docs, and CHANGELOG

## Test plan
- [x] `--override` replaces existing asset (new UUID, no duplicate)
- [x] `--override --restore-metadata` preserves all metadata fields through replacement
- [x] `--override` without `--restore-metadata` drops metadata as expected
- [x] `--override --restore-metadata` on asset with no metadata works cleanly
- [x] `--restore-metadata` without `--override` is rejected by CLI parser
- [x] All tests performed against live Physna API in `/Julian/Puzzle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)