### PR TITLE
Add `asset similarity` command for pairwise match scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-30
+
+### Added
+- **`asset similarity` command** - Get the pairwise geometric (and, when enabled, volumetric) match scores between two specific assets, backed by the Physna `GetMatchScores` API endpoint. Unlike `asset geometric-match`, which searches the tenant for assets similar to one reference, this command compares two assets you already know.
+  - Each asset is identified by **either** a UUID **or** a path, resolved to a UUID via the shared `resolve_asset` helper: `--reference-uuid`/`--reference-path` and `--candidate-uuid`/`--candidate-path` (each pair is mutually exclusive and required)
+  - Output supports JSON (default) and CSV (with optional `--headers`), and includes a UI comparison URL, consistent with the other match commands
+  - The `volumetric` score is included only when volumetric scoring is enabled for the tenant; otherwise it is omitted from JSON and left blank in CSV
+  - Available under the alias `asset match-scores`
+  - Affects `pcli2 asset similarity` (and its `match-scores` alias)
+
 ## [1.1.10] - 2026-05-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ pcli2 folder geometric-match --folder-path "/Root/SearchFolder/" --threshold 90.
 
 # Exclusive matching - only show matches where both assets belong to the specified paths
 pcli2 folder geometric-match --folder-path "/Root/SearchFolder/" --threshold 90.0 --exclusive
+
+# Compare two specific assets and get their pairwise match scores
+# (each asset can be given by --*-path or --*-uuid; alias: asset match-scores)
+pcli2 asset similarity --reference-path "/Root/Models/block1.stl" --candidate-path "/Root/Models/block2.stl"
 ```
 
 #### Exclusive Matching

--- a/docs/src/geometric-matching.md
+++ b/docs/src/geometric-matching.md
@@ -6,6 +6,7 @@ PCLI2 provides powerful geometric matching capabilities to find similar assets i
 - [Overview](#overview)
 - [Single Asset Matching](#single-asset-matching)
 - [Folder-Based Matching](#folder-based-matching)
+- [Direct Asset Similarity (Match Scores)](#direct-asset-similarity-match-scores)
 - [Threshold Settings](#threshold-settings)
 - [Performance Options](#performance-options)
 - [Error Handling](#error-handling)
@@ -205,6 +206,83 @@ For folders with many assets, consider these strategies:
 2. **Increase concurrency**: Use more concurrent operations (but watch resource usage)
 3. **Process in batches**: Break large folders into smaller subfolders
 
+## Direct Asset Similarity (Match Scores)
+
+While `geometric-match` searches your tenant for assets similar to a single
+reference, `asset similarity` compares **two specific assets** and returns the
+pairwise match scores between them. Use it when you already know both assets you
+want to compare.
+
+Each asset can be identified by **either** its UUID **or** its path — PCLI2
+resolves paths to UUIDs automatically:
+
+- Reference (source) asset: `--reference-uuid` or `--reference-path`
+- Candidate (target) asset: `--candidate-uuid` or `--candidate-path`
+
+Both assets must be 3D models in a finished state, and they must be different
+assets (comparing an asset with itself is rejected by the API).
+
+### Basic Usage
+
+```bash
+# Compare two assets by path
+pcli2 asset similarity \
+  --reference-path /Root/Folder/block1.stl \
+  --candidate-path /Root/Folder/block2.stl
+
+# Mix identifiers: reference by UUID, candidate by path
+pcli2 asset similarity \
+  --reference-uuid 123e4567-e89b-12d3-a456-426614174000 \
+  --candidate-path /Root/Folder/block2.stl
+
+# CSV output with headers
+pcli2 asset similarity \
+  --reference-path /Root/Folder/block1.stl \
+  --candidate-path /Root/Folder/block2.stl \
+  --format csv --headers
+```
+
+> The command is also available under the alias `pcli2 asset match-scores`.
+
+### Output Formats
+
+#### JSON Format (Default)
+
+```json
+{
+  "referenceAssetPath": "/Root/Folder/block1.stl",
+  "referenceAssetUuid": "123e4567-e89b-12d3-a456-426614174000",
+  "candidateAssetPath": "/Root/Folder/block2.stl",
+  "candidateAssetUuid": "987fc321-fedc-ba98-7654-43210fedcba9",
+  "geometric": {
+    "matchPercentage": 90.21,
+    "forwardMatchPercentage": 86.58,
+    "reverseMatchPercentage": 86.58
+  },
+  "comparisonUrl": "https://app.physna.com/tenants/demo-1/compare?asset1Id=123e4567-e89b-12d3-a456-426614174000&asset2Id=987fc321-fedc-ba98-7654-43210fedcba9&tenant1Id=tenant-uuid&tenant2Id=tenant-uuid&searchType=geometric&matchPercentage=90.21"
+}
+```
+
+The `geometric` scores describe how similar the two models are:
+
+- **matchPercentage**: Overall geometric similarity (100% = geometrically identical)
+- **forwardMatchPercentage**: How much of the reference asset's geometry exists in the candidate
+- **reverseMatchPercentage**: How much of the candidate asset's geometry exists in the reference
+
+A `volumetric` object (with its own `matchPercentage`) is included **only** when
+volumetric scoring is enabled for your tenant; otherwise it is omitted. Contact
+Physna sales to enable volumetric scoring.
+
+#### CSV Format
+
+```csv
+REFERENCE_ASSET_PATH,CANDIDATE_ASSET_PATH,MATCH_PERCENTAGE,FORWARD_MATCH_PERCENTAGE,REVERSE_MATCH_PERCENTAGE,VOLUMETRIC_MATCH_PERCENTAGE,REFERENCE_ASSET_UUID,CANDIDATE_ASSET_UUID,COMPARISON_URL
+/Root/Folder/block1.stl,/Root/Folder/block2.stl,90.21,86.58,86.58,,123e4567-e89b-12d3-a456-426614174000,987fc321-fedc-ba98-7654-43210fedcba9,https://app.physna.com/tenants/demo-1/compare?asset1Id=123e4567-e89b-12d3-a456-426614174000&asset2Id=987fc321-fedc-ba98-7654-43210fedcba9&tenant1Id=tenant-uuid&tenant2Id=tenant-uuid&searchType=geometric&matchPercentage=90.21
+```
+
+The `VOLUMETRIC_MATCH_PERCENTAGE` column is empty unless volumetric scoring is
+enabled for your tenant.
+
 ## Error Handling
 
 ### Common Errors
@@ -337,7 +415,8 @@ If you're not seeing expected matches:
 
 - `asset geometric-match` - Find matches for a single asset
 - `asset geometric-match-folder` - Find matches for all assets in a folder
+- `asset similarity` - Get pairwise match scores between two specific assets (alias: `asset match-scores`)
 - `asset list` - List assets in a folder
 - `asset get` - Get detailed asset information
 
-Use `pcli2 asset geometric-match --help` and `pcli2 asset geometric-match-folder --help` for detailed command information.
+Use `pcli2 asset geometric-match --help`, `pcli2 asset geometric-match-folder --help`, and `pcli2 asset similarity --help` for detailed command information.

--- a/src/actions/assets/mod.rs
+++ b/src/actions/assets/mod.rs
@@ -18,6 +18,7 @@ pub mod match_ops;
 pub mod metadata;
 pub mod print;
 pub mod reprocess;
+pub mod similarity;
 
 pub use create::{
     create_asset, create_asset_batch, create_asset_metadata_batch, update_asset_metadata,
@@ -35,3 +36,4 @@ pub use print::{
     print_asset, print_asset_dependencies, print_asset_metadata, print_folder_dependencies,
 };
 pub use reprocess::reprocess_asset;
+pub use similarity::asset_similarity;

--- a/src/actions/assets/similarity.rs
+++ b/src/actions/assets/similarity.rs
@@ -1,0 +1,123 @@
+//! Asset similarity functionality.
+//!
+//! This module provides functionality for retrieving the pairwise match scores
+//! between two specific assets using the Physna "match scores" endpoint.
+
+use crate::{
+    commands::params::{
+        PARAMETER_CANDIDATE_PATH, PARAMETER_CANDIDATE_UUID, PARAMETER_REFERENCE_PATH,
+        PARAMETER_REFERENCE_UUID,
+    },
+    error::CliError,
+    format::OutputFormatter,
+};
+use clap::ArgMatches;
+use tracing::trace;
+
+/// Get the pairwise match scores between two assets.
+///
+/// This function handles the "asset similarity" command. It resolves both a
+/// reference (source) and a candidate (target) asset from either a UUID or a
+/// path, retrieves their pairwise match scores from the API, and prints the
+/// result in the requested format (JSON or CSV).
+///
+/// # Arguments
+///
+/// * `sub_matches` - The command-line argument matches containing the command parameters
+///
+/// # Returns
+///
+/// * `Ok(())` - If the operation was successful
+/// * `Err(CliError)` - If an error occurred
+pub async fn asset_similarity(sub_matches: &ArgMatches) -> Result<(), CliError> {
+    trace!("Executing asset similarity command...");
+
+    let mut ctx = crate::context::ExecutionContext::from_args(sub_matches).await?;
+
+    let reference_uuid_param = sub_matches.get_one::<uuid::Uuid>(PARAMETER_REFERENCE_UUID);
+    let reference_path_param = sub_matches.get_one::<String>(PARAMETER_REFERENCE_PATH);
+    let candidate_uuid_param = sub_matches.get_one::<uuid::Uuid>(PARAMETER_CANDIDATE_UUID);
+    let candidate_path_param = sub_matches.get_one::<String>(PARAMETER_CANDIDATE_PATH);
+
+    // Use FormatParams for consistent format parameter handling
+    let format = crate::format_utils::FormatParams::from_args(sub_matches).format;
+
+    // Extract tenant info before calling resolve_asset to avoid borrowing conflicts
+    let tenant_uuid = *ctx.tenant_uuid();
+    let tenant_name = ctx.tenant().name.clone();
+
+    // Resolve both assets from either UUID or path using the shared helper.
+    let reference_asset = crate::actions::utils::resolve_asset(
+        ctx.api(),
+        &tenant_uuid,
+        reference_uuid_param,
+        reference_path_param,
+    )
+    .await?;
+
+    let candidate_asset = crate::actions::utils::resolve_asset(
+        ctx.api(),
+        &tenant_uuid,
+        candidate_uuid_param,
+        candidate_path_param,
+    )
+    .await?;
+
+    // Retrieve the pairwise match scores.
+    let scores = ctx
+        .api()
+        .match_scores(
+            &tenant_uuid,
+            &reference_asset.uuid(),
+            &candidate_asset.uuid(),
+        )
+        .await?;
+
+    // Build the comparison URL using the configurable UI base URL, mirroring the
+    // behaviour of the other match commands.
+    let configuration =
+        crate::configuration::Configuration::load_or_create_default().map_err(|e| {
+            CliError::ConfigurationError(
+                crate::configuration::ConfigurationError::FailedToLoadData { cause: Box::new(e) },
+            )
+        })?;
+    let ui_base_url = configuration.get_ui_base_url();
+    let base_url = ui_base_url.trim_end_matches('/');
+    let comparison_url = if base_url.ends_with("/tenants") {
+        format!(
+            "{}/{}/compare?asset1Id={}&asset2Id={}&tenant1Id={}&tenant2Id={}&searchType=geometric&matchPercentage={:.2}",
+            base_url,
+            tenant_name,
+            reference_asset.uuid(),
+            candidate_asset.uuid(),
+            tenant_uuid,
+            tenant_uuid,
+            scores.geometric.match_percentage
+        )
+    } else {
+        format!(
+            "{}/tenants/{}/compare?asset1Id={}&asset2Id={}&tenant1Id={}&tenant2Id={}&searchType=geometric&matchPercentage={:.2}",
+            base_url,
+            tenant_name,
+            reference_asset.uuid(),
+            candidate_asset.uuid(),
+            tenant_uuid,
+            tenant_uuid,
+            scores.geometric.match_percentage
+        )
+    };
+
+    let similarity = crate::model::AssetSimilarity {
+        reference_asset_path: reference_asset.path(),
+        reference_asset_uuid: reference_asset.uuid(),
+        candidate_asset_path: candidate_asset.path(),
+        candidate_asset_uuid: candidate_asset.uuid(),
+        geometric: scores.geometric,
+        volumetric: scores.volumetric,
+        comparison_url: Some(comparison_url),
+    };
+
+    println!("{}", similarity.format(format)?);
+
+    Ok(())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,10 +16,10 @@ use pcli2::keyring::Keyring;
 use pcli2::{
     actions::{
         assets::{
-            count_assets, create_asset, create_asset_batch, create_asset_metadata_batch,
-            delete_asset, delete_asset_metadata, download_asset, download_asset_thumbnail,
-            geometric_match_asset, geometric_match_folder, inventory, list_assets,
-            metadata_inference, part_match_asset, part_match_folder, print_asset,
+            asset_similarity, count_assets, create_asset, create_asset_batch,
+            create_asset_metadata_batch, delete_asset, delete_asset_metadata, download_asset,
+            download_asset_thumbnail, geometric_match_asset, geometric_match_folder, inventory,
+            list_assets, metadata_inference, part_match_asset, part_match_folder, print_asset,
             print_asset_dependencies, print_asset_metadata, print_folder_dependencies,
             reprocess_asset, text_match, update_asset_metadata, visual_match_asset,
             visual_match_folder,
@@ -43,10 +43,10 @@ use pcli2::{
             COMMAND_DEPENDENCIES, COMMAND_DOWNLOAD, COMMAND_EXPORT, COMMAND_FOLDER,
             COMMAND_FULL_INVENTORY, COMMAND_GET, COMMAND_IMPORT, COMMAND_INFERENCE, COMMAND_LIST,
             COMMAND_LOGIN, COMMAND_LOGOUT, COMMAND_MATCH, COMMAND_METADATA, COMMAND_PART_MATCH,
-            COMMAND_REPROCESS, COMMAND_STATE, COMMAND_TENANT, COMMAND_TEXT_MATCH,
-            COMMAND_THUMBNAIL, COMMAND_UPLOAD, COMMAND_USE, COMMAND_VISUAL_MATCH,
-            PARAMETER_CLIENT_ID, PARAMETER_CLIENT_SECRET, PARAMETER_FILE, PARAMETER_FORMAT,
-            PARAMETER_HEADERS, PARAMETER_OUTPUT, PARAMETER_PRETTY,
+            COMMAND_REPROCESS, COMMAND_SIMILARITY, COMMAND_STATE, COMMAND_TENANT,
+            COMMAND_TEXT_MATCH, COMMAND_THUMBNAIL, COMMAND_UPLOAD, COMMAND_USE,
+            COMMAND_VISUAL_MATCH, PARAMETER_CLIENT_ID, PARAMETER_CLIENT_SECRET, PARAMETER_FILE,
+            PARAMETER_FORMAT, PARAMETER_HEADERS, PARAMETER_OUTPUT, PARAMETER_PRETTY,
         },
     },
     format::{Formattable, FormattingError, OutputFormat, OutputFormatOptions},
@@ -351,6 +351,11 @@ pub async fn execute_command() -> Result<(), CliError> {
                 Some((COMMAND_TEXT_MATCH, sub_matches)) => {
                     trace!("Command: {} {}", COMMAND_ASSET, COMMAND_TEXT_MATCH);
                     text_match(sub_matches).await?;
+                    Ok(())
+                }
+                Some((COMMAND_SIMILARITY, sub_matches)) => {
+                    trace!("Command: {} {}", COMMAND_ASSET, COMMAND_SIMILARITY);
+                    asset_similarity(sub_matches).await?;
                     Ok(())
                 }
                 Some((COMMAND_METADATA, sub_matches)) => {

--- a/src/commands/assets.rs
+++ b/src/commands/assets.rs
@@ -5,16 +5,17 @@
 
 use crate::commands::metadata::metadata_command;
 use crate::commands::params::{
-    asset_identifier_group, asset_identifier_multiple_group, file_parameter,
-    folder_identifier_group, folder_path_parameter, folder_uuid_parameter, format_parameter,
-    format_pretty_parameter, format_with_headers_parameter, format_with_metadata_parameter,
-    multiple_files_parameter, override_parameter, path_parameter, restore_metadata_parameter,
-    tenant_parameter, uuid_parameter, COMMAND_ASSET, COMMAND_COUNTS, COMMAND_CREATE,
-    COMMAND_CREATE_BATCH, COMMAND_DELETE, COMMAND_DEPENDENCIES, COMMAND_DOWNLOAD,
-    COMMAND_FULL_INVENTORY, COMMAND_GET, COMMAND_LIST, COMMAND_MATCH, COMMAND_PART_MATCH,
-    COMMAND_REPROCESS, COMMAND_TEXT_MATCH, COMMAND_THUMBNAIL, COMMAND_VISUAL_MATCH, FORMAT_CSV,
-    FORMAT_JSON, FORMAT_TREE, PARAMETER_CONCURRENT, PARAMETER_FILE, PARAMETER_FUZZY,
-    PARAMETER_PROGRESS,
+    asset_identifier_group, asset_identifier_multiple_group, candidate_identifier_group,
+    candidate_path_parameter, candidate_uuid_parameter, file_parameter, folder_identifier_group,
+    folder_path_parameter, folder_uuid_parameter, format_parameter, format_pretty_parameter,
+    format_with_headers_parameter, format_with_metadata_parameter, multiple_files_parameter,
+    override_parameter, path_parameter, reference_identifier_group, reference_path_parameter,
+    reference_uuid_parameter, restore_metadata_parameter, tenant_parameter, uuid_parameter,
+    COMMAND_ASSET, COMMAND_COUNTS, COMMAND_CREATE, COMMAND_CREATE_BATCH, COMMAND_DELETE,
+    COMMAND_DEPENDENCIES, COMMAND_DOWNLOAD, COMMAND_FULL_INVENTORY, COMMAND_GET, COMMAND_LIST,
+    COMMAND_MATCH, COMMAND_PART_MATCH, COMMAND_REPROCESS, COMMAND_SIMILARITY, COMMAND_TEXT_MATCH,
+    COMMAND_THUMBNAIL, COMMAND_VISUAL_MATCH, FORMAT_CSV, FORMAT_JSON, FORMAT_TREE,
+    PARAMETER_CONCURRENT, PARAMETER_FILE, PARAMETER_FUZZY, PARAMETER_PROGRESS,
 };
 use clap::{Arg, ArgAction, Command};
 
@@ -229,6 +230,22 @@ pub fn asset_command() -> Command {
             .arg(format_with_metadata_parameter())  // Add metadata flag to be consistent with other match commands
             .arg(format_pretty_parameter())
             .arg(format_parameter().value_parser([FORMAT_JSON, FORMAT_CSV])) // Only support JSON and CSV as requested
+    )
+    .subcommand(
+        Command::new(COMMAND_SIMILARITY)
+            .visible_alias("match-scores") // Add alias matching the API operation name
+            .about("Get pairwise match scores between two specific assets")
+            .arg(tenant_parameter())
+            .arg(reference_uuid_parameter())
+            .arg(reference_path_parameter())
+            .arg(candidate_uuid_parameter())
+            .arg(candidate_path_parameter())
+            .arg(format_with_headers_parameter())
+            .arg(format_with_metadata_parameter()) // Required by FormatParams::from_args; no effect on this output
+            .arg(format_pretty_parameter())
+            .arg(format_parameter().value_parser([FORMAT_JSON, FORMAT_CSV]))
+            .group(reference_identifier_group())
+            .group(candidate_identifier_group()),
     )
     .subcommand(
         Command::new(COMMAND_REPROCESS)

--- a/src/commands/params.rs
+++ b/src/commands/params.rs
@@ -25,6 +25,7 @@ pub const COMMAND_PART_MATCH_FOLDER: &str = "part-match-folder"; // Allow non sn
 pub const COMMAND_VISUAL_MATCH: &str = "visual-match"; // Allow non snake case since it's used as a command name
 pub const COMMAND_VISUAL_MATCH_FOLDER: &str = "visual-match-folder"; // Allow non snake case since it's used as a command name
 pub const COMMAND_TEXT_MATCH: &str = "text-match"; // Allow non snake case since it's used as a command name
+pub const COMMAND_SIMILARITY: &str = "similarity";
 pub const COMMAND_REPROCESS: &str = "reprocess";
 pub const COMMAND_COUNTS: &str = "counts";
 pub const COMMAND_FULL_INVENTORY: &str = "inventory";
@@ -98,6 +99,10 @@ pub const PARAMETER_FOLDER_PATH: &str = "folder-path";
 pub const PARAMETER_PARENT_FOLDER_UUID: &str = "parent-folder-uuid";
 pub const PARAMETER_PARENT_FOLDER_PATH: &str = "parent-folder-path";
 pub const PARAMETER_PATH: &str = "path";
+pub const PARAMETER_REFERENCE_UUID: &str = "reference-uuid";
+pub const PARAMETER_REFERENCE_PATH: &str = "reference-path";
+pub const PARAMETER_CANDIDATE_UUID: &str = "candidate-uuid";
+pub const PARAMETER_CANDIDATE_PATH: &str = "candidate-path";
 pub const PARAMETER_REFRESH: &str = "refresh";
 pub const PARAMETER_RELOAD: &str = "reload";
 pub const PARAMETER_RECURSIVE: &str = "recursive";
@@ -279,6 +284,60 @@ pub fn asset_identifier_multiple_group() -> ArgGroup {
     ArgGroup::new("asset-identifier")
         .args([PARAMETER_UUID, PARAMETER_PATH])
         .multiple(true)
+        .required(true)
+}
+
+/// Create the reference asset UUID parameter.
+pub fn reference_uuid_parameter() -> Arg {
+    Arg::new(PARAMETER_REFERENCE_UUID)
+        .long(PARAMETER_REFERENCE_UUID)
+        .num_args(1)
+        .required(false) // used in a group with --reference-path
+        .value_parser(clap::value_parser!(Uuid))
+        .help("Reference (source) asset UUID")
+}
+
+/// Create the reference asset path parameter.
+pub fn reference_path_parameter() -> Arg {
+    Arg::new(PARAMETER_REFERENCE_PATH)
+        .long(PARAMETER_REFERENCE_PATH)
+        .num_args(1)
+        .required(false) // used in a group with --reference-uuid
+        .help("Reference (source) asset path (e.g., /Root/Child/part.stl)")
+}
+
+/// Create the candidate asset UUID parameter.
+pub fn candidate_uuid_parameter() -> Arg {
+    Arg::new(PARAMETER_CANDIDATE_UUID)
+        .long(PARAMETER_CANDIDATE_UUID)
+        .num_args(1)
+        .required(false) // used in a group with --candidate-path
+        .value_parser(clap::value_parser!(Uuid))
+        .help("Candidate (target) asset UUID")
+}
+
+/// Create the candidate asset path parameter.
+pub fn candidate_path_parameter() -> Arg {
+    Arg::new(PARAMETER_CANDIDATE_PATH)
+        .long(PARAMETER_CANDIDATE_PATH)
+        .num_args(1)
+        .required(false) // used in a group with --candidate-uuid
+        .help("Candidate (target) asset path (e.g., /Root/Child/part.stl)")
+}
+
+/// Create reference asset identifier group: it must be either --reference-uuid or --reference-path
+pub fn reference_identifier_group() -> ArgGroup {
+    ArgGroup::new("reference-identifier")
+        .args([PARAMETER_REFERENCE_UUID, PARAMETER_REFERENCE_PATH])
+        .multiple(false)
+        .required(true)
+}
+
+/// Create candidate asset identifier group: it must be either --candidate-uuid or --candidate-path
+pub fn candidate_identifier_group() -> ArgGroup {
+    ArgGroup::new("candidate-identifier")
+        .args([PARAMETER_CANDIDATE_UUID, PARAMETER_CANDIDATE_PATH])
+        .multiple(false)
         .required(true)
 }
 

--- a/src/format/impls/match_ops.rs
+++ b/src/format/impls/match_ops.rs
@@ -5,9 +5,9 @@
 
 use crate::format::{CsvRecordProducer, FormattingError, OutputFormat, OutputFormatter};
 use crate::model::{
-    EnhancedGeometricSearchResponse, EnhancedPartSearchResponse, FolderGeometricMatch,
-    FolderGeometricMatchResponse, GeometricMatchPair, GeometricSearchResponse, PartMatchPair,
-    PartSearchResponse, VisualMatchPair,
+    AssetSimilarity, EnhancedGeometricSearchResponse, EnhancedPartSearchResponse,
+    FolderGeometricMatch, FolderGeometricMatchResponse, GeometricMatchPair,
+    GeometricSearchResponse, PartMatchPair, PartSearchResponse, VisualMatchPair,
 };
 
 impl CsvRecordProducer for PartSearchResponse {
@@ -797,5 +797,146 @@ impl EnhancedGeometricSearchResponse {
             }
             _ => Err(FormattingError::UnsupportedOutputFormat(f.to_string())),
         }
+    }
+}
+
+impl CsvRecordProducer for AssetSimilarity {
+    /// Get the CSV header row for AssetSimilarity records
+    fn csv_header() -> Vec<String> {
+        vec![
+            "REFERENCE_ASSET_PATH".to_string(),
+            "CANDIDATE_ASSET_PATH".to_string(),
+            "MATCH_PERCENTAGE".to_string(),
+            "FORWARD_MATCH_PERCENTAGE".to_string(),
+            "REVERSE_MATCH_PERCENTAGE".to_string(),
+            "VOLUMETRIC_MATCH_PERCENTAGE".to_string(),
+            "REFERENCE_ASSET_UUID".to_string(),
+            "CANDIDATE_ASSET_UUID".to_string(),
+            "COMPARISON_URL".to_string(),
+        ]
+    }
+
+    /// Convert the AssetSimilarity into a single CSV record
+    fn as_csv_records(&self) -> Vec<Vec<String>> {
+        vec![vec![
+            self.reference_asset_path.clone(),
+            self.candidate_asset_path.clone(),
+            format!("{}", self.geometric.match_percentage),
+            format!("{}", self.geometric.forward_match_percentage),
+            format!("{}", self.geometric.reverse_match_percentage),
+            self.volumetric
+                .as_ref()
+                .map(|v| format!("{}", v.match_percentage))
+                .unwrap_or_default(),
+            self.reference_asset_uuid.to_string(),
+            self.candidate_asset_uuid.to_string(),
+            self.comparison_url.clone().unwrap_or_default(),
+        ]]
+    }
+}
+
+impl OutputFormatter for AssetSimilarity {
+    type Item = AssetSimilarity;
+
+    /// Format the AssetSimilarity according to the specified output format
+    ///
+    /// # Arguments
+    /// * `f` - The output format to use (JSON, CSV)
+    ///
+    /// # Returns
+    /// * `Ok(String)` - The formatted output
+    /// * `Err(FormattingError)` - If formatting fails
+    fn format(&self, f: OutputFormat) -> Result<String, FormattingError> {
+        match f {
+            OutputFormat::Json(options) => {
+                if options.pretty {
+                    Ok(serde_json::to_string_pretty(self)?)
+                } else {
+                    Ok(serde_json::to_string(self)?)
+                }
+            }
+            OutputFormat::Csv(options) => Ok(self.to_csv(options.with_headers)?),
+            _ => Err(FormattingError::UnsupportedOutputFormat(f.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod similarity_tests {
+    use super::*;
+    use crate::format::OutputFormatOptions;
+    use crate::model::{GeometricMatchScores, VolumetricMatchScores};
+    use uuid::Uuid;
+
+    fn sample() -> AssetSimilarity {
+        AssetSimilarity {
+            reference_asset_path: "/Root/a.stl".to_string(),
+            reference_asset_uuid: Uuid::nil(),
+            candidate_asset_path: "/Root/b.stl".to_string(),
+            candidate_asset_uuid: Uuid::nil(),
+            geometric: GeometricMatchScores {
+                match_percentage: 87.5,
+                forward_match_percentage: 92.1,
+                reverse_match_percentage: 83.0,
+            },
+            volumetric: Some(VolumetricMatchScores {
+                match_percentage: 74.2,
+            }),
+            comparison_url: Some("https://example.com/compare".to_string()),
+        }
+    }
+
+    #[test]
+    fn json_contains_scores_and_assets() {
+        let json = sample()
+            .format(OutputFormat::Json(OutputFormatOptions::default()))
+            .unwrap();
+        assert!(json.contains("\"referenceAssetPath\":\"/Root/a.stl\""));
+        assert!(json.contains("\"candidateAssetPath\":\"/Root/b.stl\""));
+        assert!(json.contains("\"matchPercentage\":87.5"));
+        assert!(json.contains("\"forwardMatchPercentage\":92.1"));
+        assert!(json.contains("\"volumetric\""));
+    }
+
+    #[test]
+    fn json_omits_volumetric_when_absent() {
+        let mut s = sample();
+        s.volumetric = None;
+        let json = s
+            .format(OutputFormat::Json(OutputFormatOptions::default()))
+            .unwrap();
+        assert!(!json.contains("volumetric"));
+    }
+
+    #[test]
+    fn csv_with_headers_has_expected_columns() {
+        let opts = OutputFormatOptions {
+            with_metadata: false,
+            with_headers: true,
+            pretty: false,
+        };
+        let csv = sample().format(OutputFormat::Csv(opts)).unwrap();
+        let mut lines = csv.lines();
+        let header = lines.next().unwrap();
+        assert_eq!(
+            header,
+            "REFERENCE_ASSET_PATH,CANDIDATE_ASSET_PATH,MATCH_PERCENTAGE,FORWARD_MATCH_PERCENTAGE,REVERSE_MATCH_PERCENTAGE,VOLUMETRIC_MATCH_PERCENTAGE,REFERENCE_ASSET_UUID,CANDIDATE_ASSET_UUID,COMPARISON_URL"
+        );
+        let row = lines.next().unwrap();
+        assert!(row.starts_with("/Root/a.stl,/Root/b.stl,87.5,92.1,83,74.2,"));
+    }
+
+    #[test]
+    fn csv_volumetric_empty_when_absent() {
+        let mut s = sample();
+        s.volumetric = None;
+        let opts = OutputFormatOptions {
+            with_metadata: false,
+            with_headers: false,
+            pretty: false,
+        };
+        let csv = s.format(OutputFormat::Csv(opts)).unwrap();
+        // Columns: ...,REVERSE(83),VOLUMETRIC(empty),REF_UUID,...
+        assert!(csv.contains("83,,00000000-0000-0000-0000-000000000000"));
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1705,6 +1705,76 @@ impl GeometricMatchPair {
     }
 }
 
+/// Geometric similarity scores between two assets.
+///
+/// Returned by the "match scores" endpoint as part of [`MatchScoresResponse`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GeometricMatchScores {
+    /// Overall geometric similarity. 100% means the two assets are geometrically identical.
+    #[serde(rename = "matchPercentage")]
+    pub match_percentage: f64,
+    /// How much of the source (reference) asset's geometry exists in the target (candidate) asset.
+    #[serde(rename = "forwardMatchPercentage")]
+    pub forward_match_percentage: f64,
+    /// How much of the target (candidate) asset's geometry exists in the source (reference) asset.
+    #[serde(rename = "reverseMatchPercentage")]
+    pub reverse_match_percentage: f64,
+}
+
+/// Volumetric similarity scores between two assets.
+///
+/// Volumetric scoring must be explicitly enabled for the tenant, so this is
+/// optional in [`MatchScoresResponse`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VolumetricMatchScores {
+    /// Overall volumetric similarity: how much of the source asset's volume is
+    /// contained in the target asset.
+    #[serde(rename = "matchPercentage")]
+    pub match_percentage: f64,
+}
+
+/// Response from the "match scores" endpoint.
+///
+/// Holds the pairwise match scores between two specific assets, as returned by
+/// `GET /tenants/{tenantId}/assets/{assetId}/match-scores/{targetAssetId}`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MatchScoresResponse {
+    /// Geometric similarity scores (always present).
+    pub geometric: GeometricMatchScores,
+    /// Volumetric similarity scores (present only when enabled for the tenant).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volumetric: Option<VolumetricMatchScores>,
+}
+
+/// Pairwise similarity result between a reference and a candidate asset.
+///
+/// This is the output structure for the `asset similarity` command. It combines
+/// the identities of both assets with the match scores returned by the API and a
+/// link to the comparison view in the Physna UI.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AssetSimilarity {
+    /// The path of the reference (source) asset.
+    #[serde(rename = "referenceAssetPath")]
+    pub reference_asset_path: String,
+    /// The UUID of the reference (source) asset.
+    #[serde(rename = "referenceAssetUuid")]
+    pub reference_asset_uuid: Uuid,
+    /// The path of the candidate (target) asset.
+    #[serde(rename = "candidateAssetPath")]
+    pub candidate_asset_path: String,
+    /// The UUID of the candidate (target) asset.
+    #[serde(rename = "candidateAssetUuid")]
+    pub candidate_asset_uuid: Uuid,
+    /// Geometric similarity scores between the two assets.
+    pub geometric: GeometricMatchScores,
+    /// Volumetric similarity scores between the two assets, if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volumetric: Option<VolumetricMatchScores>,
+    /// The comparison URL for viewing the two assets side by side in the UI.
+    #[serde(rename = "comparisonUrl", skip_serializing_if = "Option::is_none")]
+    pub comparison_url: Option<String>,
+}
+
 // Metadata field models for Physna V3 API
 
 /// Represents a metadata field definition

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -2688,6 +2688,38 @@ impl PhysnaApiClient {
         Ok(final_response)
     }
 
+    /// Get pairwise match scores between two assets.
+    ///
+    /// Returns geometric (and, when enabled for the tenant, volumetric) match
+    /// percentages comparing how similar two 3D models are to each other. Both
+    /// assets must be 3D models in a finished state.
+    ///
+    /// # Arguments
+    /// * `tenant_uuid` - The UUID of the tenant containing both assets
+    /// * `source_asset_uuid` - The UUID of the source (reference) asset
+    /// * `target_asset_uuid` - The UUID of the target (candidate) asset to compare against
+    ///
+    /// # Returns
+    /// * `Ok(MatchScoresResponse)` - The pairwise match scores
+    /// * `Err(ApiError)` - If there's an HTTP error, authentication issue, or other API error
+    pub async fn match_scores(
+        &mut self,
+        tenant_uuid: &Uuid,
+        source_asset_uuid: &Uuid,
+        target_asset_uuid: &Uuid,
+    ) -> Result<crate::model::MatchScoresResponse, ApiError> {
+        debug!(
+            "Getting match scores for tenant_uuid: {}, source_asset_uuid: {}, target_asset_uuid: {}",
+            tenant_uuid, source_asset_uuid, target_asset_uuid
+        );
+        let url = format!(
+            "{}/tenants/{}/assets/{}/match-scores/{}",
+            self.base_url, tenant_uuid, source_asset_uuid, target_asset_uuid
+        );
+
+        self.get(&url).await
+    }
+
     /// Perform a part search to find geometrically similar assets using the part search algorithm
     ///
     /// This method uses Physna's advanced part search algorithms to find assets with similar

--- a/tests/cli_help_test.rs
+++ b/tests/cli_help_test.rs
@@ -74,6 +74,7 @@ mod cli_help_tests {
                 assert!(help_output.contains("geometric-match"));
                 assert!(help_output.contains("part-match"));
                 assert!(help_output.contains("visual-match"));
+                assert!(help_output.contains("similarity"));
                 assert!(help_output.contains("metadata"));
                 assert!(help_output.contains("dependencies"));
             } else if subcommand == "auth" {


### PR DESCRIPTION
## Summary

Adds a new `asset similarity` command (alias `asset match-scores`) that returns the pairwise geometric (and, when enabled, volumetric) match scores between two specific assets, via the Physna `GetMatchScores` endpoint (`GET /tenants/{tenantId}/assets/{assetId}/match-scores/{targetAssetId}`).

Unlike `asset geometric-match` (which searches the tenant for assets similar to one reference), this compares two assets you already know.

## Usage

```
pcli2 asset similarity (--reference-uuid <uuid> | --reference-path <path>) \
                       (--candidate-uuid <uuid> | --candidate-path <path>) \
                       [--format json|csv] [--headers] [--pretty] [-t <tenant>]
```

Each asset may be given by UUID or path (resolved via the shared `resolve_asset` helper). Output supports JSON and CSV and includes a UI comparison URL.

## Changes
- `model.rs`: `MatchScoresResponse`, `GeometricMatchScores`, `VolumetricMatchScores`, `AssetSimilarity`
- `physna_v3.rs`: `match_scores()` API method
- `format/impls/match_ops.rs`: `CsvRecordProducer` + `OutputFormatter` for `AssetSimilarity` + unit tests
- `params.rs` / `commands/assets.rs` / `cli.rs`: arg groups, subcommand, dispatch
- Docs: geometric-matching guide + README; CHANGELOG `[1.3.0]`; version bump to 1.3.0

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, full test suite — all green
- Verified live against tenant test data (`/Julian/Puzzle`): JSON, CSV, UUID/path mixes, self-comparison rejection, and missing-asset errors all behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)