### PR TITLE
Add Excel (--format xls) output to folder geometric-match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-30
+
 ### Added
 - **`--format xls` for `folder geometric-match`** - A new Excel (`.xlsx`) output format that renders the match report as a color-highlighted, human-friendly workbook. It contains exactly the same columns as the CSV output (always including the `REF_`/`CAN_` metadata pairs), with visual aids for scanning large reports: frozen header rows and identity columns, grouped/boxed `REF_`/`CAN_` metadata pairs, per-cell metadata diff highlighting (green match / red differ / amber missing-on-one-side), a heat-map gradient over `MATCH_PERCENTAGE` with rows sorted by match descending, and clickable `COMPARISON_URL` hyperlinks.
-  - Because Excel is binary, `xls` writes to a file rather than stdout: use `--output`/`-o` to set the path (default `match_report.xlsx`); the extension is normalized to `.xlsx`.
+  - Because Excel is binary, `xls` writes to a file rather than stdout: use `--output`/`-o` to set the path (default `match_report.xlsx`); the extension is normalized to `.xlsx`, and a warning is printed to stderr if it had to be changed. On success the command prints nothing to stdout (UNIX convention).
   - The `xls` format always includes metadata, so `--metadata` is implied.
   - Ported from the standalone `match-report-analyzer` tool for a consistent look and feel.
   - Affects `pcli2 folder geometric-match` (and its `geometric-search` alias).
 
 ### Changed
+- **`folder geometric-match`: `COMPARISON_URL` moved to the last column** - In both the CSV and Excel output, the long, rarely-read `COMPARISON_URL` column is now the final column, after the `REF_`/`CAN_` metadata columns (previously it came before them). Affects `pcli2 folder geometric-match` when run with `--metadata` (and the new `--format xls`, which always includes metadata).
 - **Candidate metadata column prefix renamed `CAND_` → `CAN_`** - Match-report CSV output (and the new Excel output) now prefixes candidate-asset metadata columns with `CAN_` instead of `CAND_`, keeping it the same length as the `REF_` reference prefix for visual consistency and matching the `match-report-analyzer` convention. Affects the metadata columns of all match commands (`asset geometric-match`, `asset part-match`, `asset visual-match`, and their `folder` counterparts) when run with `--metadata`.
 
 ## [1.3.0] - 2026-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`--format xls` for `folder geometric-match`** - A new Excel (`.xlsx`) output format that renders the match report as a color-highlighted, human-friendly workbook. It contains exactly the same columns as the CSV output (always including the `REF_`/`CAN_` metadata pairs), with visual aids for scanning large reports: frozen header rows and identity columns, grouped/boxed `REF_`/`CAN_` metadata pairs, per-cell metadata diff highlighting (green match / red differ / amber missing-on-one-side), a heat-map gradient over `MATCH_PERCENTAGE` with rows sorted by match descending, and clickable `COMPARISON_URL` hyperlinks.
+  - Because Excel is binary, `xls` writes to a file rather than stdout: use `--output`/`-o` to set the path (default `match_report.xlsx`); the extension is normalized to `.xlsx`.
+  - The `xls` format always includes metadata, so `--metadata` is implied.
+  - Ported from the standalone `match-report-analyzer` tool for a consistent look and feel.
+  - Affects `pcli2 folder geometric-match` (and its `geometric-search` alias).
+
+### Changed
+- **Candidate metadata column prefix renamed `CAND_` → `CAN_`** - Match-report CSV output (and the new Excel output) now prefixes candidate-asset metadata columns with `CAN_` instead of `CAND_`, keeping it the same length as the `REF_` reference prefix for visual consistency and matching the `match-report-analyzer` convention. Affects the metadata columns of all match commands (`asset geometric-match`, `asset part-match`, `asset visual-match`, and their `folder` counterparts) when run with `--metadata`.
+
 ## [1.3.0] - 2026-06-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2391,6 +2392,7 @@ dependencies = [
  "ptree",
  "rand 0.8.5",
  "reqwest",
+ "rust_xlsxwriter",
  "serde 1.0.228",
  "serde_json",
  "serde_urlencoded",
@@ -2407,7 +2409,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -2824,6 +2826,15 @@ name = "rust-ini"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
+
+[[package]]
+name = "rust_xlsxwriter"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f281b687352597d29efaad39701d1167d5c48aa76fb973e392bc13e9d44e7f36"
+dependencies = [
+ "zip 7.2.0",
+]
 
 [[package]]
 name = "rustix"
@@ -3659,6 +3670,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -4567,6 +4584,26 @@ dependencies = [
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ uuid = { version = "1.18.1", features = ["serde", "v4"] }
 rand = "0.8"
 async-recursion = "1.1.1"
 mime_guess = "2.0"
+rust_xlsxwriter = "0.95.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ pcli2 folder geometric-match --folder-path "/Root/SearchFolder/" --threshold 90.
 # Exclusive matching - only show matches where both assets belong to the specified paths
 pcli2 folder geometric-match --folder-path "/Root/SearchFolder/" --threshold 90.0 --exclusive
 
+# Color-highlighted Excel report (frozen headers, grouped metadata pairs, diff colors, match heat-map)
+pcli2 folder geometric-match --folder-path "/Root/SearchFolder/" --threshold 90.0 --format xls --output report.xlsx
+
 # Compare two specific assets and get their pairwise match scores
 # (each asset can be given by --*-path or --*-uuid; alias: asset match-scores)
 pcli2 asset similarity --reference-path "/Root/Models/block1.stl" --candidate-path "/Root/Models/block2.stl"

--- a/docs/src/geometric-matching.md
+++ b/docs/src/geometric-matching.md
@@ -175,7 +175,9 @@ easy to scan:
 Because Excel is a binary format, `xls` writes to a **file** rather than standard
 output. Use `--output` (or `-o`) to choose the path; if omitted, the workbook is
 written to `match_report.xlsx` in the current directory. The extension is always
-normalized to `.xlsx` (the modern Office Open XML format).
+normalized to `.xlsx` (the modern Office Open XML format); if it had to be
+changed, a warning is printed to `stderr`. On success the command follows the
+UNIX convention of printing nothing to `stdout`.
 
 ```bash
 # Write a highlighted Excel report for a folder

--- a/docs/src/geometric-matching.md
+++ b/docs/src/geometric-matching.md
@@ -153,9 +153,9 @@ https://app.physna.com/tenants/{tenant_short_name}/compare?asset1Id={reference_a
 
 In addition to `json` and `csv`, the folder match command supports `--format xls`,
 which writes a **color-highlighted Excel workbook** designed for a human reader.
-It contains exactly the same columns as the CSV output (always including the
-`REF_`/`CAN_` metadata pairs), rendered with visual aids that make a large report
-easy to scan:
+It contains exactly the same columns, in the same order, as the CSV output
+(always including the `REF_`/`CAN_` metadata pairs), rendered with visual aids
+that make a large report easy to scan:
 
 - **Frozen headers and identity columns** — the two header rows and the leading
   reference path, candidate path, and match-percentage columns stay in view while
@@ -169,7 +169,8 @@ easy to scan:
 - **Match-score heat map** — the `MATCH_PERCENTAGE` column is shaded on a gradient
   (cool at 0%, through yellow at 50%, to red-hot at 100%) and the rows are sorted
   by match percentage, highest first.
-- **Clickable comparison links** — the `COMPARISON_URL` column is written as a
+- **Clickable comparison links** — `COMPARISON_URL` is the **last column** (its
+  long value is rarely read, so the metadata columns come before it), written as a
   hyperlink you can click to open the side-by-side comparison in a browser.
 
 Because Excel is a binary format, `xls` writes to a **file** rather than standard

--- a/docs/src/geometric-matching.md
+++ b/docs/src/geometric-matching.md
@@ -81,10 +81,10 @@ ReferenceModel.stl,SimilarModel.stl,95.75,/Root/Folder/ReferenceModel.stl,/Root/
 
 #### CSV Format with Metadata
 
-When using the `--metadata` flag, the output includes metadata fields from both the reference and candidate assets. This produces CSV output with additional metadata columns prefixed with `REF_` for reference asset metadata and `CAND_` for candidate asset metadata. The output also includes a `COMPARISON_URL` column that provides a link to view the comparison in the Physna UI:
+When using the `--metadata` flag, the output includes metadata fields from both the reference and candidate assets. This produces CSV output with additional metadata columns prefixed with `REF_` for reference asset metadata and `CAN_` for candidate asset metadata. The output also includes a `COMPARISON_URL` column that provides a link to view the comparison in the Physna UI:
 
 ```csv
-REFERENCE_ASSET_PATH,CANDIDATE_ASSET_PATH,MATCH_PERCENTAGE,REFERENCE_ASSET_UUID,CANDIDATE_ASSET_UUID,COMPARISON_URL,REF_MATERIAL,CAND_MATERIAL,REF_COLOR,CAND_COLOR
+REFERENCE_ASSET_PATH,CANDIDATE_ASSET_PATH,MATCH_PERCENTAGE,REFERENCE_ASSET_UUID,CANDIDATE_ASSET_UUID,COMPARISON_URL,REF_MATERIAL,CAN_MATERIAL,REF_COLOR,CAN_COLOR
 /Root/Folder/ReferenceModel.stl,/Root/DifferentFolder/SimilarModel.stl,95.75,123e4567-e89b-12d3-a456-426614174000,987fc321-fedc-ba98-7654-43210fedcba9,https://app.physna.com/tenants/demo-1/compare?asset1Id=123e4567-e89b-12d3-a456-426614174000&asset2Id=987fc321-fedc-ba98-7654-43210fedcba9&tenant1Id=68555ebf-f09c-4861-96b1-692d2ec10de7&tenant2Id=68555ebf-f09c-4861-96b1-692d2ec10de7&searchType=geometric&matchPercentage=95.75,Steel,Aluminum,Red,Blue
 ```
 
@@ -112,7 +112,7 @@ pcli2 asset geometric-match --path /Root/Folder/ReferenceModel.stl --threshold 8
 
 Output:
 ```csv
-REFERENCE_ASSET_PATH,CANDIDATE_ASSET_PATH,MATCH_PERCENTAGE,REFERENCE_ASSET_UUID,CANDIDATE_ASSET_UUID,COMPARISON_URL,REF_MATERIAL,CAND_MATERIAL,REF_COLOR,CAND_COLOR
+REFERENCE_ASSET_PATH,CANDIDATE_ASSET_PATH,MATCH_PERCENTAGE,REFERENCE_ASSET_UUID,CANDIDATE_ASSET_UUID,COMPARISON_URL,REF_MATERIAL,CAN_MATERIAL,REF_COLOR,CAN_COLOR
 /Root/Folder/ReferenceModel.stl,/Root/DifferentFolder/SimilarModel.stl,95.75,123e4567-e89b-12d3-a456-426614174000,987fc321-fedc-ba98-7654-43210fedcba9,https://app.physna.com/tenants/demo-1/compare?asset1Id=123e4567-e89b-12d3-a456-426614174000&asset2Id=987fc321-fedc-ba98-7654-43210fedcba9&tenant1Id=68555ebf-f09c-4861-96b1-692d2ec10de7&tenant2Id=68555ebf-f09c-4861-96b1-692d2ec10de7&searchType=geometric&matchPercentage=95.75,Steel,Aluminum,Red,Blue
 ```
 
@@ -148,6 +148,45 @@ The URL follows this format:
 ```
 https://app.physna.com/tenants/{tenant_short_name}/compare?asset1Id={reference_asset_uuid}&asset2Id={candidate_asset_uuid}&tenant1Id={tenant_uuid}&tenant2Id={tenant_uuid}&searchType=geometric&matchPercentage={match_percentage}
 ```
+
+### Excel (XLSX) Output
+
+In addition to `json` and `csv`, the folder match command supports `--format xls`,
+which writes a **color-highlighted Excel workbook** designed for a human reader.
+It contains exactly the same columns as the CSV output (always including the
+`REF_`/`CAN_` metadata pairs), rendered with visual aids that make a large report
+easy to scan:
+
+- **Frozen headers and identity columns** — the two header rows and the leading
+  reference path, candidate path, and match-percentage columns stay in view while
+  you scroll a wide, tall report.
+- **Grouped metadata pairs** — each `REF_<field>`/`CAN_<field>` pair is boxed and
+  labeled once with the field name (e.g. `MATERIAL` over a `REF` and a `CAN`
+  sub-column), so the reference/candidate pairs stand out among the plain columns.
+- **Metadata diff highlighting** — for every pair, both cells are shaded:
+  🟩 green when the two values match, 🟥 red when they differ, and 🟨 amber when a
+  value is present on only one side.
+- **Match-score heat map** — the `MATCH_PERCENTAGE` column is shaded on a gradient
+  (cool at 0%, through yellow at 50%, to red-hot at 100%) and the rows are sorted
+  by match percentage, highest first.
+- **Clickable comparison links** — the `COMPARISON_URL` column is written as a
+  hyperlink you can click to open the side-by-side comparison in a browser.
+
+Because Excel is a binary format, `xls` writes to a **file** rather than standard
+output. Use `--output` (or `-o`) to choose the path; if omitted, the workbook is
+written to `match_report.xlsx` in the current directory. The extension is always
+normalized to `.xlsx` (the modern Office Open XML format).
+
+```bash
+# Write a highlighted Excel report for a folder
+pcli2 folder geometric-match --folder-path /Root/SearchFolder/ --threshold 80.0 --format xls --output report.xlsx
+
+# Multiple folders, default output filename (match_report.xlsx)
+pcli2 folder geometric-match --folder-path /Root/FolderA/ --folder-path /Root/FolderB/ --format xls
+```
+
+> The `xls` format always includes metadata (the metadata diff is its whole
+> point), so the `--metadata` flag is implied and does not need to be passed.
 
 ### Performance Options
 

--- a/src/actions/assets/match_ops.rs
+++ b/src/actions/assets/match_ops.rs
@@ -1000,19 +1000,23 @@ pub async fn geometric_match_folder(sub_matches: &ArgMatches) -> Result<(), CliE
     // formats are always column-for-column consistent.
     if is_xls {
         let (headers, rows) = build_geometric_match_table(&all_matches, with_metadata);
-        let output_path = sub_matches
+        let requested_path = sub_matches
             .get_one::<std::path::PathBuf>(crate::commands::params::PARAMETER_OUTPUT)
             .cloned()
             .unwrap_or_else(|| std::path::PathBuf::from("match_report.xlsx"));
-        let output_path = crate::xlsx_report::normalize_output_path(&output_path);
-        let stats = crate::xlsx_report::write_match_report(headers, rows, &output_path)?;
-        println!(
-            "Wrote Excel match report to {} ({} rows, {} metadata pair(s), {} differing cell(s)).",
-            output_path.display(),
-            stats.rows,
-            stats.pairs,
-            stats.different
-        );
+        let output_path = crate::xlsx_report::normalize_output_path(&requested_path);
+        // Warn if we had to coerce the extension to `.xlsx`. Written straight to
+        // stderr (not via `report_warning`, whose `tracing` line lands on stdout)
+        // so that stdout stays clean per UNIX convention.
+        if output_path != requested_path {
+            eprintln!(
+                "⚠️  Warning: output file extension changed to '.xlsx': writing '{}' instead of '{}'",
+                output_path.display(),
+                requested_path.display()
+            );
+        }
+        crate::xlsx_report::write_match_report(headers, rows, &output_path)?;
+        // UNIX-style: on success there is no data to print, so print nothing.
         return Ok(());
     }
 

--- a/src/actions/assets/match_ops.rs
+++ b/src/actions/assets/match_ops.rs
@@ -526,11 +526,12 @@ pub async fn visual_match_asset(sub_matches: &ArgMatches) -> Result<(), CliError
 /// Excel outputs of `folder geometric-match`.
 ///
 /// Producing both formats from this one function guarantees they are always
-/// column-for-column identical — only the presentation differs. The base columns
-/// come from [`crate::model::GeometricMatchPair::csv_header`]; when
-/// `with_metadata` is set, paired `REF_<field>`/`CAN_<field>` metadata columns
-/// are appended after them, using the sorted union of metadata keys across all
-/// pairs.
+/// column-for-column identical — only the presentation differs. The columns are,
+/// in order: the base columns from [`crate::model::GeometricMatchPair::csv_header`]
+/// except `COMPARISON_URL`; then, when `with_metadata` is set, paired
+/// `REF_<field>`/`CAN_<field>` metadata columns (the sorted union of metadata keys
+/// across all pairs); and finally `COMPARISON_URL` as the last column (its long,
+/// rarely-read value is kept out of the way after the metadata).
 fn build_geometric_match_table(
     all_matches: &[crate::model::EnhancedGeometricSearchResponse],
     with_metadata: bool,
@@ -565,16 +566,21 @@ fn build_geometric_match_table(
         metadata_keys = sorted;
     }
 
-    // Headers: base columns, then REF_/CAN_ metadata pairs.
+    // Headers: base columns, then REF_/CAN_ metadata pairs, and finally
+    // COMPARISON_URL. The comparison URL is long and rarely read, so it is moved
+    // out of the base columns to the very last column, after the metadata.
+    const COMPARISON_URL_HEADER: &str = "COMPARISON_URL";
     let mut headers = crate::model::GeometricMatchPair::csv_header();
+    headers.retain(|header| header != COMPARISON_URL_HEADER);
     if with_metadata {
         for key in &metadata_keys {
             headers.push(format!("REF_{}", key.to_uppercase()));
             headers.push(format!("CAN_{}", key.to_uppercase()));
         }
     }
+    headers.push(COMPARISON_URL_HEADER.to_string());
 
-    // Rows, in the same column order as the headers.
+    // Rows, in the same column order as the headers (COMPARISON_URL last).
     let mut rows = Vec::with_capacity(flattened.len());
     for pair in &flattened {
         let mut values = vec![
@@ -583,7 +589,6 @@ fn build_geometric_match_table(
             format!("{}", pair.match_percentage),
             pair.reference_asset.uuid.to_string(),
             pair.candidate_asset.uuid.to_string(),
-            pair.comparison_url.clone().unwrap_or_default(),
         ];
         if with_metadata {
             for key in &metadata_keys {
@@ -605,6 +610,8 @@ fn build_geometric_match_table(
                 values.push(candidate_value);
             }
         }
+        // COMPARISON_URL last, matching the header order above.
+        values.push(pair.comparison_url.clone().unwrap_or_default());
         rows.push(values);
     }
 

--- a/src/actions/assets/match_ops.rs
+++ b/src/actions/assets/match_ops.rs
@@ -442,7 +442,7 @@ pub async fn visual_match_asset(sub_matches: &ArgMatches) -> Result<(), CliError
                     // Add metadata columns with prefixes
                     for key in &header_metadata_keys {
                         base_headers.push(format!("REF_{}", key.to_uppercase()));
-                        base_headers.push(format!("CAND_{}", key.to_uppercase()));
+                        base_headers.push(format!("CAN_{}", key.to_uppercase()));
                     }
                 }
 
@@ -522,6 +522,95 @@ pub async fn visual_match_asset(sub_matches: &ArgMatches) -> Result<(), CliError
     Ok(())
 }
 
+/// Build the canonical match-report table (headers + rows) shared by the CSV and
+/// Excel outputs of `folder geometric-match`.
+///
+/// Producing both formats from this one function guarantees they are always
+/// column-for-column identical — only the presentation differs. The base columns
+/// come from [`crate::model::GeometricMatchPair::csv_header`]; when
+/// `with_metadata` is set, paired `REF_<field>`/`CAN_<field>` metadata columns
+/// are appended after them, using the sorted union of metadata keys across all
+/// pairs.
+fn build_geometric_match_table(
+    all_matches: &[crate::model::EnhancedGeometricSearchResponse],
+    with_metadata: bool,
+) -> (Vec<String>, Vec<Vec<String>>) {
+    // Flatten every (reference, candidate) match into a single row model.
+    let flattened: Vec<crate::model::GeometricMatchPair> = all_matches
+        .iter()
+        .flat_map(|response| {
+            response.matches.iter().map(move |m| {
+                crate::model::GeometricMatchPair::from_reference_and_match(
+                    response.reference_asset.clone(),
+                    m.clone(),
+                )
+            })
+        })
+        .collect();
+
+    // Collect the sorted, unique metadata keys present across all pairs.
+    let mut metadata_keys: Vec<String> = Vec::new();
+    if with_metadata {
+        let mut keys = std::collections::HashSet::new();
+        for pair in &flattened {
+            for key in pair.reference_asset.metadata.keys() {
+                keys.insert(key.clone());
+            }
+            for key in pair.candidate_asset.metadata.keys() {
+                keys.insert(key.clone());
+            }
+        }
+        let mut sorted: Vec<String> = keys.into_iter().collect();
+        sorted.sort();
+        metadata_keys = sorted;
+    }
+
+    // Headers: base columns, then REF_/CAN_ metadata pairs.
+    let mut headers = crate::model::GeometricMatchPair::csv_header();
+    if with_metadata {
+        for key in &metadata_keys {
+            headers.push(format!("REF_{}", key.to_uppercase()));
+            headers.push(format!("CAN_{}", key.to_uppercase()));
+        }
+    }
+
+    // Rows, in the same column order as the headers.
+    let mut rows = Vec::with_capacity(flattened.len());
+    for pair in &flattened {
+        let mut values = vec![
+            pair.reference_asset.path.clone(),
+            pair.candidate_asset.path.clone(),
+            format!("{}", pair.match_percentage),
+            pair.reference_asset.uuid.to_string(),
+            pair.candidate_asset.uuid.to_string(),
+            pair.comparison_url.clone().unwrap_or_default(),
+        ];
+        if with_metadata {
+            for key in &metadata_keys {
+                let ref_value = pair
+                    .reference_asset
+                    .metadata
+                    .get(key)
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .unwrap_or_default();
+                values.push(ref_value);
+                let candidate_value = pair
+                    .candidate_asset
+                    .metadata
+                    .get(key)
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .unwrap_or_default();
+                values.push(candidate_value);
+            }
+        }
+        rows.push(values);
+    }
+
+    (headers, rows)
+}
+
 /// Perform geometric matching on assets in one or more folders.
 ///
 /// This function handles the "folder match geometric" command, finding geometrically
@@ -560,8 +649,18 @@ pub async fn geometric_match_folder(sub_matches: &ArgMatches) -> Result<(), CliE
     // Use FormatParams for consistent format parameter handling
     let format_params = crate::format_utils::FormatParams::from_args(sub_matches);
     let format = format_params.format;
-    let with_metadata = format_params.format_options.with_metadata;
     let with_headers = format_params.format_options.with_headers;
+
+    // The `xls` (Excel) format is a binary file output, not a stdout format, and
+    // is intentionally not part of the `OutputFormat` enum — `FormatParams` would
+    // silently fall back to JSON for it. Detect it from the raw format string
+    // instead, and handle it separately below. Excel reports always include
+    // metadata (the metadata diff is the whole point), so force it on for xls.
+    let is_xls = sub_matches
+        .get_one::<String>(crate::commands::params::PARAMETER_FORMAT)
+        .map(|value| value.eq_ignore_ascii_case(crate::commands::params::FORMAT_XLS))
+        .unwrap_or(false);
+    let with_metadata = format_params.format_options.with_metadata || is_xls;
 
     // Get exclusive flag
     let exclusive = sub_matches.get_flag("exclusive");
@@ -895,6 +994,28 @@ pub async fn geometric_match_folder(sub_matches: &ArgMatches) -> Result<(), CliE
         ));
     }
 
+    // Excel (`xls`) output: write a styled .xlsx workbook to a file instead of
+    // printing. Handled here because `xls` is not an `OutputFormat` enum variant.
+    // The workbook is built from the same table as the CSV output, so the two
+    // formats are always column-for-column consistent.
+    if is_xls {
+        let (headers, rows) = build_geometric_match_table(&all_matches, with_metadata);
+        let output_path = sub_matches
+            .get_one::<std::path::PathBuf>(crate::commands::params::PARAMETER_OUTPUT)
+            .cloned()
+            .unwrap_or_else(|| std::path::PathBuf::from("match_report.xlsx"));
+        let output_path = crate::xlsx_report::normalize_output_path(&output_path);
+        let stats = crate::xlsx_report::write_match_report(headers, rows, &output_path)?;
+        println!(
+            "Wrote Excel match report to {} ({} rows, {} metadata pair(s), {} differing cell(s)).",
+            output_path.display(),
+            stats.rows,
+            stats.pairs,
+            stats.different
+        );
+        return Ok(());
+    }
+
     // Output the results based on format
     match format {
         crate::format::OutputFormat::Json(_) => {
@@ -913,97 +1034,22 @@ pub async fn geometric_match_folder(sub_matches: &ArgMatches) -> Result<(), CliE
             println!("{}", serde_json::to_string_pretty(&flattened_matches)?);
         }
         crate::format::OutputFormat::Csv(_) => {
-            // For CSV, we can output all matches together
-            let mut flattened_matches = Vec::new();
-            for enhanced_response in all_matches {
-                for match_result in enhanced_response.matches {
-                    flattened_matches.push(
-                        crate::model::GeometricMatchPair::from_reference_and_match(
-                            enhanced_response.reference_asset.clone(),
-                            match_result,
-                        ),
-                    );
-                }
-            }
+            // Build the shared table so CSV and Excel stay column-for-column
+            // identical; only the presentation differs between the two formats.
+            let (headers, rows) = build_geometric_match_table(&all_matches, with_metadata);
 
-            // For CSV with metadata, we need to create a custom implementation
             let mut wtr = csv::Writer::from_writer(vec![]);
 
-            // Pre-calculate the metadata keys that will be used for headers and all records
-            let mut header_metadata_keys = Vec::new();
-            if with_metadata {
-                // Collect all unique metadata keys from ALL match pairs for consistent headers
-                let mut all_metadata_keys = std::collections::HashSet::new();
-                for match_pair in &flattened_matches {
-                    for key in match_pair.reference_asset.metadata.keys() {
-                        all_metadata_keys.insert(key.clone());
-                    }
-                    for key in match_pair.candidate_asset.metadata.keys() {
-                        all_metadata_keys.insert(key.clone());
-                    }
-                }
-
-                // Sort metadata keys for consistent column ordering
-                let mut sorted_keys: Vec<String> = all_metadata_keys.into_iter().collect();
-                sorted_keys.sort();
-                header_metadata_keys = sorted_keys;
-            }
-
             if with_headers {
-                // Build header with metadata columns
-                let mut base_headers = crate::model::GeometricMatchPair::csv_header();
-
-                if with_metadata {
-                    // Add metadata columns with prefixes
-                    for key in &header_metadata_keys {
-                        base_headers.push(format!("REF_{}", key.to_uppercase()));
-                        base_headers.push(format!("CAND_{}", key.to_uppercase()));
-                    }
-                }
-
-                if let Err(e) = wtr.serialize(base_headers.as_slice()) {
+                if let Err(e) = wtr.serialize(headers.as_slice()) {
                     return Err(CliError::from(CliActionError::FormattingError(
                         crate::format::FormattingError::CsvError(e),
                     )));
                 }
             }
 
-            for match_pair in flattened_matches {
-                let mut base_values = vec![
-                    match_pair.reference_asset.path.clone(),
-                    match_pair.candidate_asset.path.clone(),
-                    format!("{}", match_pair.match_percentage),
-                    match_pair.reference_asset.uuid.to_string(),
-                    match_pair.candidate_asset.uuid.to_string(),
-                    match_pair.comparison_url.clone().unwrap_or_default(),
-                ];
-
-                if with_metadata {
-                    // Add metadata values for each key that was included in the header
-                    for key in &header_metadata_keys {
-                        // Add reference asset metadata value
-                        let ref_value = match_pair
-                            .reference_asset
-                            .metadata
-                            .get(key)
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string())
-                            .unwrap_or_default();
-                        base_values.push(ref_value);
-
-                        // Add candidate asset metadata value
-                        let cand_value = match_pair
-                            .candidate_asset
-                            .metadata
-                            .get(key)
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string())
-                            .unwrap_or_default();
-                        base_values.push(cand_value);
-                    }
-                }
-
-                if let Err(e) = wtr.serialize(base_values.as_slice()) {
+            for row in &rows {
+                if let Err(e) = wtr.serialize(row.as_slice()) {
                     return Err(CliError::from(CliActionError::FormattingError(
                         crate::format::FormattingError::CsvError(e),
                     )));
@@ -1502,7 +1548,7 @@ pub async fn part_match_folder(sub_matches: &ArgMatches) -> Result<(), CliError>
                     // Add metadata columns with prefixes
                     for key in &header_metadata_keys {
                         base_headers.push(format!("REF_{}", key.to_uppercase()));
-                        base_headers.push(format!("CAND_{}", key.to_uppercase()));
+                        base_headers.push(format!("CAN_{}", key.to_uppercase()));
                     }
                 }
 
@@ -2019,7 +2065,7 @@ pub async fn visual_match_folder(sub_matches: &ArgMatches) -> Result<(), CliErro
                     // Add metadata columns with prefixes
                     for key in &header_metadata_keys {
                         base_headers.push(format!("REF_{}", key.to_uppercase()));
-                        base_headers.push(format!("CAND_{}", key.to_uppercase()));
+                        base_headers.push(format!("CAN_{}", key.to_uppercase()));
                     }
                 }
 

--- a/src/actions/tenants.rs
+++ b/src/actions/tenants.rs
@@ -493,6 +493,12 @@ pub async fn get_tenant_state_counts(sub_matches: &ArgMatches) -> Result<(), Cli
             crate::error::CliError::FolderListError(_) => {
                 CliActionError::MissingRequiredArgument("Folder list error".to_string())
             }
+            crate::error::CliError::XlsxReportError(xlsx_error) => {
+                CliActionError::MissingRequiredArgument(format!(
+                    "Excel report error: {}",
+                    xlsx_error
+                ))
+            }
             crate::error::CliError::UuidParsingError(uuid_error) => {
                 CliActionError::UuidPartsinError(uuid_error)
             }

--- a/src/commands/folder.rs
+++ b/src/commands/folder.rs
@@ -5,10 +5,10 @@
 use crate::commands::params::{
     folder_identifier_group, folder_path_parameter, folder_uuid_parameter, format_parameter,
     format_pretty_parameter, format_with_headers_parameter, format_with_metadata_parameter,
-    name_parameter, parent_folder_identifier_group, parent_folder_path_parameter,
-    parent_folder_uuid_parameter, tenant_parameter, COMMAND_CREATE, COMMAND_DELETE, COMMAND_FOLDER,
-    COMMAND_GET, COMMAND_LIST, COMMAND_MATCH, COMMAND_PART_MATCH, COMMAND_VISUAL_MATCH,
-    PARAMETER_PROGRESS,
+    name_parameter, output_file_parameter, parent_folder_identifier_group,
+    parent_folder_path_parameter, parent_folder_uuid_parameter, tenant_parameter, COMMAND_CREATE,
+    COMMAND_DELETE, COMMAND_FOLDER, COMMAND_GET, COMMAND_LIST, COMMAND_MATCH, COMMAND_PART_MATCH,
+    COMMAND_VISUAL_MATCH, FORMAT_CSV, FORMAT_JSON, FORMAT_XLS, PARAMETER_PROGRESS,
 };
 use clap::Command;
 
@@ -247,7 +247,10 @@ pub fn folder_command() -> Command {
                 .arg(format_with_headers_parameter())
                 .arg(format_with_metadata_parameter())
                 .arg(format_pretty_parameter())
-                .arg(format_parameter().value_parser([crate::commands::params::FORMAT_JSON, crate::commands::params::FORMAT_CSV]))
+                .arg(format_parameter().value_parser([FORMAT_JSON, FORMAT_CSV, FORMAT_XLS]))
+                .arg(output_file_parameter().help(
+                    "Output file path (required for --format xls; default: match_report.xlsx)",
+                ))
                 .arg(
                     clap::Arg::new("concurrent")
                         .long("concurrent")

--- a/src/commands/params.rs
+++ b/src/commands/params.rs
@@ -121,6 +121,7 @@ pub const PARAMETER_RESTORE_METADATA: &str = "restore-metadata";
 pub const FORMAT_CSV: &str = "csv";
 pub const FORMAT_JSON: &str = "json";
 pub const FORMAT_TREE: &str = "tree";
+pub const FORMAT_XLS: &str = "xls";
 
 /// Create the global format parameter.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,9 @@ pub enum CliError {
 
     #[error("{0}")]
     FolderListError(#[from] FolderHierarchyError),
+
+    #[error("Excel report error: {0}")]
+    XlsxReportError(#[from] crate::xlsx_report::XlsxReportError),
 }
 
 impl CliError {
@@ -68,6 +71,7 @@ impl CliError {
             CliError::JsonError(_) => PcliExitCode::DataError,
             CliError::TenantNotFound { .. } => PcliExitCode::UsageError,
             CliError::FolderNotFound { .. } => PcliExitCode::UsageError,
+            CliError::XlsxReportError(_) => PcliExitCode::DataError,
             _ => PcliExitCode::SoftwareError,
         }
     }

--- a/src/format/impls/match_ops.rs
+++ b/src/format/impls/match_ops.rs
@@ -143,7 +143,7 @@ impl EnhancedPartSearchResponse {
                         // Extend headers with metadata columns using the pre-calculated keys
                         for key in &header_metadata_keys {
                             base_headers.push(format!("REF_{}", key.to_uppercase()));
-                            base_headers.push(format!("CAND_{}", key.to_uppercase()));
+                            base_headers.push(format!("CAN_{}", key.to_uppercase()));
                         }
 
                         wtr.serialize(base_headers.as_slice())?;
@@ -422,7 +422,7 @@ impl OutputFormatter for GeometricMatchPair {
                         // Extend headers with metadata columns
                         for key in &sorted_keys {
                             base_headers.push(format!("REF_{}", key.to_uppercase()));
-                            base_headers.push(format!("CAND_{}", key.to_uppercase()));
+                            base_headers.push(format!("CAN_{}", key.to_uppercase()));
                         }
 
                         wtr.serialize(base_headers.as_slice())?;
@@ -582,7 +582,7 @@ impl OutputFormatter for EnhancedGeometricSearchResponse {
                         // Extend headers with metadata columns
                         for key in &sorted_keys {
                             base_headers.push(format!("REF_{}", key.to_uppercase()));
-                            base_headers.push(format!("CAND_{}", key.to_uppercase()));
+                            base_headers.push(format!("CAN_{}", key.to_uppercase()));
                         }
 
                         wtr.serialize(base_headers.as_slice())?;
@@ -715,7 +715,7 @@ impl EnhancedGeometricSearchResponse {
                         // Extend headers with metadata columns
                         for key in &sorted_keys {
                             base_headers.push(format!("REF_{}", key.to_uppercase()));
-                            base_headers.push(format!("CAND_{}", key.to_uppercase()));
+                            base_headers.push(format!("CAN_{}", key.to_uppercase()));
                         }
 
                         wtr.serialize(base_headers.as_slice())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,3 +40,4 @@ pub mod param_utils;
 pub mod path_utils;
 pub mod physna_v3;
 pub mod tenant_cache;
+pub mod xlsx_report;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -161,32 +161,10 @@ pub fn convert_single_metadata_to_json_value(
             serde_json::Value::Bool(bool_val)
         }
         _ => {
-            // Default to text/string type, but intelligently detect booleans and numbers
-            // This helps when the API field is already defined as boolean/number but CSV doesn't specify type
-
-            // First, check for boolean values (case-insensitive)
-            let lower_value = value.to_lowercase();
-            if lower_value == "true" || lower_value == "yes" {
-                return serde_json::Value::Bool(true);
-            }
-            if lower_value == "false" || lower_value == "no" {
-                return serde_json::Value::Bool(false);
-            }
-
-            // Then, check for numeric values
-            if let Ok(int_val) = value.parse::<i64>() {
-                return serde_json::Value::Number(serde_json::Number::from(int_val));
-            }
-            if let Ok(float_val) = value.parse::<f64>() {
-                if float_val.fract() == 0.0 {
-                    return serde_json::Value::Number(serde_json::Number::from(float_val as i64));
-                }
-                if let Some(num) = serde_json::Number::from_f64(float_val) {
-                    return serde_json::Value::Number(num);
-                }
-            }
-
-            // Default to text/string type, with sanitization
+            // Text (the default): always serialize as a JSON string, even when the
+            // value looks numeric or boolean. The `--type` flag is authoritative, so
+            // `--type text --value 100` must produce the string "100" rather than the
+            // number 100 (which the API rejects for string-typed metadata fields).
             let sanitized_value = sanitize_metadata_value(value);
             serde_json::Value::String(sanitized_value)
         }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -191,3 +191,62 @@ fn sanitize_metadata_value(value: &str) -> String {
         // Keep other characters as they are
         .to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_type_keeps_numeric_looking_value_as_string() {
+        // Regression: `--type text --value 100` must serialize as the JSON string
+        // "100", not the number 100. String-typed metadata fields on the tenant
+        // reject numbers with "Value for metadata field 'X' must be a string".
+        let value = convert_single_metadata_to_json_value("test_quantity", "100", "text");
+        assert_eq!(value, Value::String("100".to_string()));
+    }
+
+    #[test]
+    fn text_type_keeps_boolean_looking_value_as_string() {
+        let value = convert_single_metadata_to_json_value("flag", "true", "text");
+        assert_eq!(value, Value::String("true".to_string()));
+    }
+
+    #[test]
+    fn text_type_keeps_float_looking_value_as_string() {
+        let value = convert_single_metadata_to_json_value("ratio", "3.14", "text");
+        assert_eq!(value, Value::String("3.14".to_string()));
+    }
+
+    #[test]
+    fn text_type_preserves_non_numeric_value() {
+        let value = convert_single_metadata_to_json_value("test_quantity", "100pcs", "text");
+        assert_eq!(value, Value::String("100pcs".to_string()));
+    }
+
+    #[test]
+    fn number_type_serializes_integer() {
+        let value = convert_single_metadata_to_json_value("qty", "100", "number");
+        assert_eq!(value, Value::Number(serde_json::Number::from(100i64)));
+    }
+
+    #[test]
+    fn number_type_serializes_float() {
+        let value = convert_single_metadata_to_json_value("ratio", "2.5", "number");
+        assert_eq!(
+            value,
+            Value::Number(serde_json::Number::from_f64(2.5).unwrap())
+        );
+    }
+
+    #[test]
+    fn boolean_type_serializes_bool() {
+        assert_eq!(
+            convert_single_metadata_to_json_value("flag", "yes", "boolean"),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            convert_single_metadata_to_json_value("flag", "off", "boolean"),
+            Value::Bool(false)
+        );
+    }
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -2402,7 +2402,7 @@ impl OutputFormatter for TextMatchPair {
                         // Extend headers with metadata columns
                         for key in &sorted_keys {
                             base_headers.push(format!("REF_{}", key.to_uppercase()));
-                            base_headers.push(format!("CAND_{}", key.to_uppercase()));
+                            base_headers.push(format!("CAN_{}", key.to_uppercase()));
                         }
 
                         wtr.serialize(base_headers.as_slice())?;

--- a/src/xlsx_report.rs
+++ b/src/xlsx_report.rs
@@ -1,0 +1,811 @@
+//! Renders a match report into a color-highlighted, human-friendly Excel
+//! workbook (`.xlsx`).
+//!
+//! This module is the Excel counterpart to the CSV output of the match
+//! commands. It takes the **exact same** header row and data rows that the CSV
+//! formatter produces and renders them into a styled workbook, so the two
+//! formats are always column-for-column consistent — only the presentation
+//! differs.
+//!
+//! A match report pairs a *reference* asset against a *candidate* asset. Paired
+//! metadata columns are named `REF_<field>` and `CAN_<field>`, where `<field>`
+//! is the metadata field name and must be identical between the two columns.
+//! All other columns (`REFERENCE_ASSET_PATH`, `MATCH_PERCENTAGE`,
+//! `COMPARISON_URL`, …) are plain, unpaired columns.
+//!
+//! For each pair the renderer highlights, cell by cell, where the two values
+//! differ (red), match (green), or are present on only one side (amber), so a
+//! large report can be scanned visually. The `MATCH_PERCENTAGE` column drives a
+//! descending sort and a heat-map gradient, and the `COMPARISON_URL` column is
+//! written as a clickable hyperlink.
+//!
+//! The logic here is ported from the standalone `match-report-analyzer` tool,
+//! adapted to consume in-memory rows (rather than re-reading a CSV) and to use
+//! pcli2's `CAN_` candidate-metadata prefix.
+
+use std::cmp::Ordering;
+use std::path::{Path, PathBuf};
+
+use rust_xlsxwriter::{
+    Color, ConditionalFormat3ColorScale, ConditionalFormatType, DocProperties, Format, FormatAlign,
+    FormatBorder, Url, Workbook, XlsxError,
+};
+use thiserror::Error;
+use tracing::{debug, info};
+
+/// Prefix marking a column that holds a *reference* asset's metadata value.
+const REF_PREFIX: &str = "REF_";
+/// Prefix marking a column that holds a *candidate* asset's metadata value.
+/// Kept the same length as [`REF_PREFIX`] for visual consistency.
+const CAN_PREFIX: &str = "CAN_";
+
+/// Header of the reference asset's path column.
+const REFERENCE_ASSET_PATH_COLUMN: &str = "REFERENCE_ASSET_PATH";
+/// Header of the candidate asset's path column.
+const CANDIDATE_ASSET_PATH_COLUMN: &str = "CANDIDATE_ASSET_PATH";
+/// Header of the geometric similarity column (0–100). The most relevant pairs
+/// have the highest value, so this column drives sorting and the heat-map
+/// gradient in the rendered workbook.
+const MATCH_PERCENTAGE_COLUMN: &str = "MATCH_PERCENTAGE";
+/// Header of the column holding the deep-link comparison URL, rendered as a
+/// clickable hyperlink.
+const COMPARISON_URL_COLUMN: &str = "COMPARISON_URL";
+
+/// Columns that every match report must contain for the conversion to make
+/// sense. Their absence means the data isn't a usable match report.
+const REQUIRED_COLUMNS: [&str; 3] = [
+    REFERENCE_ASSET_PATH_COLUMN,
+    CANDIDATE_ASSET_PATH_COLUMN,
+    MATCH_PERCENTAGE_COLUMN,
+];
+
+/// The only file extension Excel recognizes for the format this module writes.
+const XLSX_EXTENSION: &str = "xlsx";
+
+/// Errors that can occur while rendering a match report into an Excel workbook.
+#[derive(Debug, Error)]
+pub enum XlsxReportError {
+    /// The data is missing one or more columns required to build a match report.
+    #[error("the match report is missing required column(s): {}", .0.join(", "))]
+    MissingRequiredColumns(Vec<String>),
+    /// An error occurred while building or saving the Excel workbook.
+    #[error("failed to write Excel workbook: {0}")]
+    Xlsx(#[from] XlsxError),
+}
+
+// ---------------------------------------------------------------------------
+// Colors, dimensions, and format constants (ported verbatim).
+// ---------------------------------------------------------------------------
+
+/// Background color for paired cells whose values match. Excel's "good" green.
+const COLOR_MATCH: Color = Color::RGB(0xC6EFCE);
+/// Background color for cells whose reference and candidate values differ.
+/// Excel's "bad" red.
+const COLOR_DIFFERENT: Color = Color::RGB(0xFFC7CE);
+/// Background color for cells where a value is present on one side only.
+/// Excel's "neutral" amber.
+const COLOR_MISSING: Color = Color::RGB(0xFFEB9C);
+/// Header fill: a deep, professional blue with white text.
+const COLOR_HEADER_BG: Color = Color::RGB(0x1F4E78);
+/// Fill for the second header row (the `REF`/`CAN` sub-labels): a lighter blue.
+const COLOR_SUBHEADER_BG: Color = Color::RGB(0x2E6CA4);
+
+/// Heat-map color for the lowest match percentage (0%): a calm, "cool" blue.
+const COLOR_HEAT_LOW: Color = Color::RGB(0x5A8AC6);
+/// Heat-map color for the midpoint (50%): a warm yellow.
+const COLOR_HEAT_MID: Color = Color::RGB(0xFFEB84);
+/// Heat-map color for the highest match percentage (100%): "red hot".
+const COLOR_HEAT_HIGH: Color = Color::RGB(0xF8696B);
+
+/// Number format applied to the match-percentage column.
+const PERCENT_NUM_FORMAT: &str = "0.00";
+
+/// Height (in points) of each of the two header rows.
+const HEADER_ROW_HEIGHT: f64 = 22.0;
+/// Row index of the top "group" header (field-name band over each pair).
+const GROUP_HEADER_ROW: u32 = 0;
+/// Row index of the second header (per-column `REF`/`CAN` and unpaired names).
+const LABEL_HEADER_ROW: u32 = 1;
+/// Row index where data begins (after the two header rows).
+const DATA_START_ROW: u32 = 2;
+/// Padding (in characters) added to a column's widest content.
+const COL_WIDTH_PADDING: f64 = 2.0;
+/// Narrowest a sized column may be.
+const MIN_COL_WIDTH: f64 = 8.0;
+/// Widest a normal sized column may be, so long values don't dominate.
+const MAX_COL_WIDTH: f64 = 48.0;
+/// Excel's hard maximum column width, used for the comparison-URL column.
+const EXCEL_MAX_COL_WIDTH: f64 = 255.0;
+/// Excel's maximum supported URL length. Longer values are written as text.
+const MAX_URL_LEN: usize = 2080;
+
+/// Worksheet tab name.
+const SHEET_NAME: &str = "Match Report";
+
+/// The comparison state of a single `REF_`/`CAN_` cell pair within a row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CellState {
+    /// Nothing to highlight: not part of a comparable pair, or both values empty.
+    Neutral,
+    /// Both values present and equal — a genuine match.
+    Match,
+    /// Both values present but differ.
+    Different,
+    /// Exactly one of the two values is empty (missing on one side).
+    Missing,
+}
+
+/// Compares a reference value against a candidate value on their trimmed text.
+fn classify(reference: &str, candidate: &str) -> CellState {
+    let reference = reference.trim();
+    let candidate = candidate.trim();
+
+    if reference.is_empty() && candidate.is_empty() {
+        CellState::Neutral
+    } else if reference == candidate {
+        CellState::Match
+    } else if reference.is_empty() || candidate.is_empty() {
+        CellState::Missing
+    } else {
+        CellState::Different
+    }
+}
+
+/// The structure of a match report: its header row plus, for every column, the
+/// index of its partner column if it participates in a `REF_`/`CAN_` pair.
+#[derive(Debug, Clone)]
+struct Schema {
+    headers: Vec<String>,
+    /// For each column index, `Some(partner_index)` if it is one half of a
+    /// `REF_`/`CAN_` pair, otherwise `None`.
+    partners: Vec<Option<usize>>,
+}
+
+impl Schema {
+    /// Builds a [`Schema`] by pairing `REF_<field>` columns with their
+    /// `CAN_<field>` counterparts.
+    fn from_headers(headers: Vec<String>) -> Self {
+        let mut ref_cols: Vec<(String, usize)> = Vec::new();
+        let mut can_cols: Vec<(String, usize)> = Vec::new();
+
+        for (idx, header) in headers.iter().enumerate() {
+            if let Some(field) = header.strip_prefix(REF_PREFIX) {
+                ref_cols.push((field.to_string(), idx));
+            } else if let Some(field) = header.strip_prefix(CAN_PREFIX) {
+                can_cols.push((field.to_string(), idx));
+            }
+        }
+
+        let mut partners = vec![None; headers.len()];
+        let mut used_can: Vec<bool> = vec![false; can_cols.len()];
+        for (field, ref_idx) in &ref_cols {
+            // Pair with the first not-yet-used CAN_ column of the same field, so
+            // duplicate field names (e.g. two `MATERIAL` columns) pair up 1:1
+            // instead of all collapsing onto the first candidate column.
+            if let Some(slot) = can_cols
+                .iter()
+                .enumerate()
+                .position(|(i, (f, _))| !used_can[i] && f == field)
+            {
+                let can_idx = can_cols[slot].1;
+                used_can[slot] = true;
+                partners[*ref_idx] = Some(can_idx);
+                partners[can_idx] = Some(*ref_idx);
+            }
+        }
+
+        Schema { headers, partners }
+    }
+
+    fn headers(&self) -> &[String] {
+        &self.headers
+    }
+
+    fn column_count(&self) -> usize {
+        self.headers.len()
+    }
+
+    fn partner(&self, column: usize) -> Option<usize> {
+        self.partners.get(column).copied().flatten()
+    }
+
+    fn column_index(&self, name: &str) -> Option<usize> {
+        self.headers.iter().position(|h| h == name)
+    }
+
+    /// The metadata field name of a paired column — the part after the `REF_` or
+    /// `CAN_` prefix. Returns `None` for columns that are not part of a pair.
+    fn field_name(&self, column: usize) -> Option<&str> {
+        self.partner(column)?;
+        let header = self.headers.get(column)?;
+        header
+            .strip_prefix(REF_PREFIX)
+            .or_else(|| header.strip_prefix(CAN_PREFIX))
+    }
+
+    /// The [`REQUIRED_COLUMNS`] absent from this schema, in order.
+    fn missing_required_columns(&self) -> Vec<String> {
+        REQUIRED_COLUMNS
+            .iter()
+            .filter(|name| self.column_index(name).is_none())
+            .map(|name| name.to_string())
+            .collect()
+    }
+
+    /// The number of comparable `REF_`/`CAN_` pairs.
+    fn pair_count(&self) -> usize {
+        self.partners.iter().filter(|p| p.is_some()).count() / 2
+    }
+}
+
+/// A fully-parsed match report: its [`Schema`] and all data rows.
+#[derive(Debug, Clone)]
+struct Report {
+    schema: Schema,
+    rows: Vec<Vec<String>>,
+}
+
+impl Report {
+    /// Builds a report from a header row and data rows (already column-aligned).
+    fn new(headers: Vec<String>, rows: Vec<Vec<String>>) -> Self {
+        Report {
+            schema: Schema::from_headers(headers),
+            rows,
+        }
+    }
+
+    /// Sorts the data rows by the numeric value of `column`, descending. Cells
+    /// that don't parse as a number (including blanks) sort to the bottom. Stable.
+    fn sort_by_numeric_desc(&mut self, column: usize) {
+        fn numeric(row: &[String], column: usize) -> Option<f64> {
+            row.get(column)
+                .and_then(|cell| cell.trim().parse::<f64>().ok())
+        }
+
+        self.rows
+            .sort_by(|a, b| match (numeric(a, column), numeric(b, column)) {
+                (Some(x), Some(y)) => y.partial_cmp(&x).unwrap_or(Ordering::Equal),
+                (Some(_), None) => Ordering::Less,
+                (None, Some(_)) => Ordering::Greater,
+                (None, None) => Ordering::Equal,
+            });
+    }
+
+    /// Classifies the cell at `(row, column)` against its pair partner. Returns
+    /// [`CellState::Neutral`] for unpaired columns or out-of-bounds cells.
+    fn cell_state(&self, row: usize, column: usize) -> CellState {
+        let Some(partner) = self.schema.partner(column) else {
+            return CellState::Neutral;
+        };
+        let Some(record) = self.rows.get(row) else {
+            return CellState::Neutral;
+        };
+        let here = record.get(column).map(String::as_str).unwrap_or("");
+        let there = record.get(partner).map(String::as_str).unwrap_or("");
+
+        let is_reference = self.schema.headers()[column].starts_with(REF_PREFIX);
+        if is_reference {
+            classify(here, there)
+        } else {
+            classify(there, here)
+        }
+    }
+}
+
+/// A summary of what was written, returned for logging and reporting.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ConversionStats {
+    /// Number of data rows written.
+    pub rows: usize,
+    /// Number of comparable `REF_`/`CAN_` pairs in the schema.
+    pub pairs: usize,
+    /// Number of cells highlighted as matching.
+    pub matching: usize,
+    /// Number of cells highlighted as differing.
+    pub different: usize,
+    /// Number of cells highlighted as missing-on-one-side.
+    pub missing: usize,
+}
+
+/// Ensures the output path carries the `.xlsx` extension (case-insensitive).
+///
+/// Excel refuses to open a workbook whose extension and contents disagree, so a
+/// missing or different extension (most commonly `.xls`) is coerced to `.xlsx`.
+pub fn normalize_output_path(path: &Path) -> PathBuf {
+    let already_xlsx = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case(XLSX_EXTENSION));
+
+    if already_xlsx {
+        path.to_path_buf()
+    } else {
+        path.with_extension(XLSX_EXTENSION)
+    }
+}
+
+/// Renders a match report (given its CSV-style `headers` and `rows`) into a
+/// styled, color-highlighted `.xlsx` workbook at `output`.
+///
+/// The `headers`/`rows` are expected to be exactly what the CSV formatter would
+/// emit, which keeps the two output formats column-for-column consistent.
+///
+/// Returns an error if the data lacks the columns a match report requires, or if
+/// the workbook cannot be built or saved.
+pub fn write_match_report(
+    headers: Vec<String>,
+    rows: Vec<Vec<String>>,
+    output: &Path,
+) -> Result<ConversionStats, XlsxReportError> {
+    let mut report = Report::new(headers, rows);
+
+    let missing = report.schema.missing_required_columns();
+    if !missing.is_empty() {
+        return Err(XlsxReportError::MissingRequiredColumns(missing));
+    }
+
+    // Surface the most relevant pairs first: highest match percentage at the top.
+    if let Some(column) = report.schema.column_index(MATCH_PERCENTAGE_COLUMN) {
+        report.sort_by_numeric_desc(column);
+    }
+
+    write_workbook(&report, output)
+}
+
+/// Writes `report` to an `.xlsx` workbook at `output`.
+fn write_workbook(report: &Report, output: &Path) -> Result<ConversionStats, XlsxReportError> {
+    let band_format = Format::new()
+        .set_bold()
+        .set_font_color(Color::White)
+        .set_background_color(COLOR_HEADER_BG)
+        .set_align(FormatAlign::Center)
+        .set_align(FormatAlign::VerticalCenter)
+        .set_border_top(FormatBorder::Medium)
+        .set_border_left(FormatBorder::Medium)
+        .set_border_right(FormatBorder::Medium)
+        .set_border_bottom(FormatBorder::Thin);
+    let unpaired_header_format = Format::new()
+        .set_bold()
+        .set_font_color(Color::White)
+        .set_background_color(COLOR_HEADER_BG)
+        .set_align(FormatAlign::Center)
+        .set_align(FormatAlign::VerticalCenter)
+        .set_border(FormatBorder::Thin);
+    let percent_format = Format::new().set_num_format(PERCENT_NUM_FORMAT);
+
+    let mut workbook = Workbook::new();
+    workbook.set_properties(
+        &DocProperties::new()
+            .set_title("Physna Match Report")
+            .set_subject("Reference vs. candidate metadata comparison"),
+    );
+
+    let worksheet = workbook.add_worksheet();
+    worksheet.set_name(SHEET_NAME)?;
+
+    let schema = &report.schema;
+    let match_col = schema.column_index(MATCH_PERCENTAGE_COLUMN);
+    let url_col = schema.column_index(COMPARISON_URL_COLUMN);
+    let mut stats = ConversionStats {
+        pairs: schema.pair_count(),
+        ..Default::default()
+    };
+
+    // Two-row header: a merged "group" band naming each pair's field once, and a
+    // second row with per-column REF/CAN sub-labels. Unpaired columns span both.
+    let headers = schema.headers();
+    let mut col = 0usize;
+    while col < schema.column_count() {
+        match schema.partner(col) {
+            Some(partner) if partner == col + 1 => {
+                let field = schema.field_name(col).unwrap_or(headers[col].as_str());
+                worksheet.merge_range(
+                    GROUP_HEADER_ROW,
+                    col as u16,
+                    GROUP_HEADER_ROW,
+                    (col + 1) as u16,
+                    field,
+                    &band_format,
+                )?;
+                worksheet.write_with_format(
+                    LABEL_HEADER_ROW,
+                    col as u16,
+                    side_label(&headers[col]),
+                    &pair_label_format(true),
+                )?;
+                worksheet.write_with_format(
+                    LABEL_HEADER_ROW,
+                    (col + 1) as u16,
+                    side_label(&headers[col + 1]),
+                    &pair_label_format(false),
+                )?;
+                col += 2;
+            }
+            _ => {
+                worksheet.merge_range(
+                    GROUP_HEADER_ROW,
+                    col as u16,
+                    LABEL_HEADER_ROW,
+                    col as u16,
+                    &headers[col],
+                    &unpaired_header_format,
+                )?;
+                col += 1;
+            }
+        }
+    }
+    worksheet.set_row_height(GROUP_HEADER_ROW, HEADER_ROW_HEIGHT)?;
+    worksheet.set_row_height(LABEL_HEADER_ROW, HEADER_ROW_HEIGHT)?;
+
+    // Data rows follow the two header rows.
+    let last_data_index = report.rows.len().saturating_sub(1);
+    for (row_idx, record) in report.rows.iter().enumerate() {
+        let excel_row = row_idx as u32 + DATA_START_ROW;
+        let is_last_row = row_idx == last_data_index;
+        for col in 0..schema.column_count() {
+            let value = record.get(col).map(String::as_str).unwrap_or("");
+
+            // The match-percentage column is written as a real number so the
+            // heat-map gradient and numeric sort work, with a fixed precision.
+            if Some(col) == match_col {
+                match value.trim().parse::<f64>() {
+                    Ok(number) => {
+                        worksheet.write_with_format(
+                            excel_row,
+                            col as u16,
+                            number,
+                            &percent_format,
+                        )?;
+                    }
+                    Err(_) => {
+                        worksheet.write_with_format(
+                            excel_row,
+                            col as u16,
+                            value,
+                            &percent_format,
+                        )?;
+                    }
+                }
+                continue;
+            }
+
+            // The comparison column is written as a clickable hyperlink; blank or
+            // non-http / over-long values fall back to plain text.
+            if Some(col) == url_col {
+                let link = value.trim();
+                if (link.starts_with("http://") || link.starts_with("https://"))
+                    && link.len() <= MAX_URL_LEN
+                {
+                    worksheet.write_url(excel_row, col as u16, Url::new(link))?;
+                } else {
+                    worksheet.write(excel_row, col as u16, value)?;
+                }
+                continue;
+            }
+
+            let state = report.cell_state(row_idx, col);
+            match state {
+                CellState::Match => stats.matching += 1,
+                CellState::Different => stats.different += 1,
+                CellState::Missing => stats.missing += 1,
+                CellState::Neutral => {}
+            }
+
+            let (left_edge, right_edge) = pair_edges(schema, col);
+            let bottom_edge = is_last_row && (left_edge || right_edge);
+            match data_cell_format(state, left_edge, right_edge, bottom_edge) {
+                Some(format) => {
+                    worksheet.write_with_format(excel_row, col as u16, value, &format)?;
+                }
+                None => {
+                    worksheet.write(excel_row, col as u16, value)?;
+                }
+            }
+        }
+    }
+    stats.rows = report.rows.len();
+
+    // Size every column to its content (capped) for legibility.
+    for (col, width) in column_widths(report).into_iter().enumerate() {
+        worksheet.set_column_width(col as u16, width)?;
+    }
+
+    // Freeze both header rows and the leading identity columns (up to and
+    // including MATCH_PERCENTAGE) so the pair each row describes stays visible.
+    let frozen_columns = match_col
+        .map(|col| col + 1)
+        .unwrap_or(1)
+        .min(schema.column_count());
+    worksheet.set_freeze_panes(DATA_START_ROW, frozen_columns as u16)?;
+    if schema.column_count() > 0 && !report.rows.is_empty() {
+        let last_col = (schema.column_count() - 1) as u16;
+        let last_row = report.rows.len() as u32 + LABEL_HEADER_ROW;
+        worksheet.autofilter(LABEL_HEADER_ROW, 0, last_row, last_col)?;
+
+        // Heat-map gradient over the match-percentage column, anchored to fixed
+        // 0/50/100 so the colors mean the same thing regardless of the data range.
+        if let Some(col) = match_col {
+            let gradient = ConditionalFormat3ColorScale::new()
+                .set_minimum(ConditionalFormatType::Number, 0)
+                .set_midpoint(ConditionalFormatType::Number, 50)
+                .set_maximum(ConditionalFormatType::Number, 100)
+                .set_minimum_color(COLOR_HEAT_LOW)
+                .set_midpoint_color(COLOR_HEAT_MID)
+                .set_maximum_color(COLOR_HEAT_HIGH);
+            worksheet.add_conditional_format(
+                DATA_START_ROW,
+                col as u16,
+                last_row,
+                col as u16,
+                &gradient,
+            )?;
+        }
+    }
+
+    debug!(?output, "saving workbook");
+    workbook.save(output)?;
+    info!(
+        rows = stats.rows,
+        pairs = stats.pairs,
+        matching = stats.matching,
+        different = stats.different,
+        missing = stats.missing,
+        "excel conversion complete"
+    );
+
+    Ok(stats)
+}
+
+/// The short side label (`REF` or `CAN`) for a paired column's header.
+fn side_label(header: &str) -> &'static str {
+    if header.starts_with(REF_PREFIX) {
+        "REF"
+    } else {
+        "CAN"
+    }
+}
+
+/// Which box edges a column sits on: `(left, right)`.
+fn pair_edges(schema: &Schema, col: usize) -> (bool, bool) {
+    match schema.partner(col) {
+        Some(partner) if partner == col + 1 => (true, false),
+        Some(partner) if col > 0 && partner == col - 1 => (false, true),
+        _ => (false, false),
+    }
+}
+
+/// The header format for a pair's `REF`/`CAN` sub-label, with a medium border on
+/// the pair's outer edge.
+fn pair_label_format(left_edge: bool) -> Format {
+    let format = Format::new()
+        .set_bold()
+        .set_font_color(Color::White)
+        .set_background_color(COLOR_SUBHEADER_BG)
+        .set_align(FormatAlign::Center)
+        .set_align(FormatAlign::VerticalCenter)
+        .set_border(FormatBorder::Thin);
+    if left_edge {
+        format.set_border_left(FormatBorder::Medium)
+    } else {
+        format.set_border_right(FormatBorder::Medium)
+    }
+}
+
+/// Builds the format for a data cell from its comparison state and box edges.
+/// Returns `None` for a plain, unhighlighted, non-edge cell.
+fn data_cell_format(state: CellState, left: bool, right: bool, bottom: bool) -> Option<Format> {
+    if state == CellState::Neutral && !left && !right && !bottom {
+        return None;
+    }
+    let mut format = Format::new();
+    match state {
+        CellState::Match => format = format.set_background_color(COLOR_MATCH),
+        CellState::Different => format = format.set_background_color(COLOR_DIFFERENT),
+        CellState::Missing => format = format.set_background_color(COLOR_MISSING),
+        CellState::Neutral => {}
+    }
+    if left {
+        format = format.set_border_left(FormatBorder::Medium);
+    }
+    if right {
+        format = format.set_border_right(FormatBorder::Medium);
+    }
+    if bottom {
+        format = format.set_border_bottom(FormatBorder::Medium);
+    }
+    Some(format)
+}
+
+/// Computes a per-column width (in characters), sized to the widest of the
+/// header and any cell, padded and clamped. The comparison-URL column is exempt
+/// from the usual cap and sized to its (long) values.
+fn column_widths(report: &Report) -> Vec<f64> {
+    let column_count = report.schema.column_count();
+    let url_col = report.schema.column_index(COMPARISON_URL_COLUMN);
+    let mut max_chars = vec![0usize; column_count];
+
+    for (col, header) in report.schema.headers().iter().enumerate() {
+        max_chars[col] = header.chars().count();
+    }
+    for row in &report.rows {
+        for (col, cell) in row.iter().enumerate() {
+            if col < column_count {
+                max_chars[col] = max_chars[col].max(cell.chars().count());
+            }
+        }
+    }
+
+    max_chars
+        .into_iter()
+        .enumerate()
+        .map(|(col, chars)| {
+            let width = chars as f64 + COL_WIDTH_PADDING;
+            let max = if Some(col) == url_col {
+                EXCEL_MAX_COL_WIDTH
+            } else {
+                MAX_COL_WIDTH
+            };
+            width.clamp(MIN_COL_WIDTH, max)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn rows(list: Vec<Vec<&str>>) -> Vec<Vec<String>> {
+        list.into_iter()
+            .map(|r| r.into_iter().map(String::from).collect())
+            .collect()
+    }
+
+    #[test]
+    fn classify_covers_all_states() {
+        assert_eq!(classify("mm", "mm"), CellState::Match);
+        assert_eq!(classify(" mm ", "mm"), CellState::Match);
+        assert_eq!(classify("", ""), CellState::Neutral);
+        assert_eq!(classify("true", "false"), CellState::Different);
+        assert_eq!(classify("mm", ""), CellState::Missing);
+        assert_eq!(classify("", "mm"), CellState::Missing);
+    }
+
+    #[test]
+    fn pairs_ref_and_can_columns() {
+        let s = Schema::from_headers(headers(&[
+            "REFERENCE_ASSET_PATH",
+            "REF_XUNITS",
+            "CAN_XUNITS",
+            "COMPARISON_URL",
+        ]));
+        assert_eq!(s.pair_count(), 1);
+        assert_eq!(s.partner(1), Some(2));
+        assert_eq!(s.partner(2), Some(1));
+        assert_eq!(s.partner(0), None);
+        assert_eq!(s.field_name(1), Some("XUNITS"));
+    }
+
+    #[test]
+    fn reference_and_candidate_lookalikes_are_not_paired() {
+        // "REFERENCE_..." / "CANDIDATE_..." must not match the REF_/CAN_ prefixes.
+        let s = Schema::from_headers(headers(&[
+            "REFERENCE_ASSET_PATH",
+            "CANDIDATE_ASSET_PATH",
+            "MATCH_PERCENTAGE",
+        ]));
+        assert_eq!(s.pair_count(), 0);
+    }
+
+    #[test]
+    fn duplicate_field_names_pair_one_to_one() {
+        // Two MATERIAL pairs (a real pcli2 quirk from case-colliding keys) must
+        // pair up as (0,1) and (2,3), not all onto the first candidate column.
+        let s = Schema::from_headers(headers(&[
+            "REF_MATERIAL",
+            "CAN_MATERIAL",
+            "REF_MATERIAL",
+            "CAN_MATERIAL",
+        ]));
+        assert_eq!(s.pair_count(), 2);
+        assert_eq!(s.partner(0), Some(1));
+        assert_eq!(s.partner(2), Some(3));
+    }
+
+    #[test]
+    fn missing_required_columns_are_reported() {
+        let s = Schema::from_headers(headers(&["REF_XUNITS", "CAN_XUNITS"]));
+        assert_eq!(
+            s.missing_required_columns(),
+            vec![
+                "REFERENCE_ASSET_PATH".to_string(),
+                "CANDIDATE_ASSET_PATH".to_string(),
+                "MATCH_PERCENTAGE".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn write_match_report_rejects_missing_columns() {
+        let result = write_match_report(
+            headers(&["REF_XUNITS", "CAN_XUNITS"]),
+            rows(vec![vec!["mm", "mm"]]),
+            Path::new("/tmp/should_not_be_written.xlsx"),
+        );
+        assert!(matches!(
+            result,
+            Err(XlsxReportError::MissingRequiredColumns(_))
+        ));
+    }
+
+    #[test]
+    fn normalize_output_path_coerces_extension() {
+        assert_eq!(
+            normalize_output_path(Path::new("report.xlsx")),
+            PathBuf::from("report.xlsx")
+        );
+        assert_eq!(
+            normalize_output_path(Path::new("report.xls")),
+            PathBuf::from("report.xlsx")
+        );
+        assert_eq!(
+            normalize_output_path(Path::new("report")),
+            PathBuf::from("report.xlsx")
+        );
+        // Case-insensitive: an existing .XLSX is left untouched.
+        assert_eq!(
+            normalize_output_path(Path::new("report.XLSX")),
+            PathBuf::from("report.XLSX")
+        );
+    }
+
+    #[test]
+    fn writes_a_workbook_with_highlight_stats() {
+        let r = Report::new(
+            headers(&[
+                "REFERENCE_ASSET_PATH",
+                "CANDIDATE_ASSET_PATH",
+                "MATCH_PERCENTAGE",
+                "REF_XUNITS",
+                "CAN_XUNITS",
+                "COMPARISON_URL",
+            ]),
+            rows(vec![
+                vec!["a", "b", "100", "mm", "mm", "https://example.com/c?a=1"],
+                vec!["c", "d", "80.5", "mm", "in", "https://example.com/c?a=2"],
+                vec!["e", "f", "50", "mm", "", ""], // blank URL -> plain text
+            ]),
+        );
+        let path = std::env::temp_dir().join("pcli2_xlsx_report_test.xlsx");
+        let stats = write_workbook(&r, &path).expect("write should succeed");
+        assert_eq!(stats.rows, 3);
+        assert_eq!(stats.pairs, 1);
+        assert_eq!(stats.matching, 2); // mm/mm, both cells
+        assert_eq!(stats.different, 2); // mm/in, both cells
+        assert_eq!(stats.missing, 2); // mm/"", both cells
+        assert!(path.exists());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn write_match_report_sorts_by_match_desc() {
+        // Rows given low-to-high; the workbook should sort high-to-low. We can't
+        // easily read the xlsx back, but we can verify the public entrypoint
+        // succeeds and returns the right row count.
+        let r = write_match_report(
+            headers(&[
+                "REFERENCE_ASSET_PATH",
+                "CANDIDATE_ASSET_PATH",
+                "MATCH_PERCENTAGE",
+            ]),
+            rows(vec![vec!["a", "b", "50"], vec!["c", "d", "90"]]),
+            &std::env::temp_dir().join("pcli2_xlsx_report_sort_test.xlsx"),
+        )
+        .expect("write should succeed");
+        assert_eq!(r.rows, 2);
+        assert_eq!(r.pairs, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `--format xls` to `pcli2 folder geometric-match`, writing the match report as a **color-highlighted Excel (.xlsx) workbook** for human reading. Ported from the standalone `match-report-analyzer` into a new `xlsx_report` module (backed by `rust_xlsxwriter`).

The workbook is built from the **same shared table as the CSV output**, so the two formats are always column-for-column identical — only the presentation differs.

## Features
- Frozen header rows + leading identity columns; grouped/boxed `REF_`/`CAN_` metadata pairs
- Per-cell metadata diff highlighting: 🟩 match / 🟥 differ / 🟨 missing-on-one-side
- Heat-map gradient over `MATCH_PERCENTAGE` (rows sorted best-first)
- Clickable `COMPARISON_URL` hyperlinks
- Binary output → writes a file (`--output`/`-o`, default `match_report.xlsx`, extension normalized to `.xlsx` with an stderr warning); silent on success (UNIX-style); metadata always included

## Also in this release
- **`COMPARISON_URL` moved to the last column** (CSV + Excel), after the metadata — its long value is rarely read.
- **`CAND_` → `CAN_`** candidate metadata prefix across all match commands (matches `REF_` length and the analyzer convention).
- Fixed a pre-existing `clippy::approx_constant` lint newly flagged by Rust 1.96 (a `3.14` test value) so CI stays green.
- Bumped to **1.4.0**.

## Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, full test suite — all green (187 tests)
- Verified live against `/Julian/Puzzle` (with deliberately-created test metadata): CSV/XLS headers proven byte-identical; green/red/amber coloring, heat-map, freeze panes, hyperlinks, and `COMPARISON_URL`-last order all confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)