### PR TITLE
Release v1.4.1 - fix visual-match pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-06-30
+
+### Fixed
+- **`visual-match` pagination** - Visual search now returns the full ranked result set instead of only the first ~20 matches. The `visual-search` API endpoint takes `page`/`perPage` as **query parameters**, but the client was sending them in the request body (which the API ignores), so every call returned only the first page. The client now sends pagination in the query string and walks all pages. Affects `pcli2 asset visual-match` and `pcli2 folder visual-match` (and their `visual-search` aliases).
+
+### Added
+- **`--limit` for the visual-match commands** - Cap the number of results returned by `asset visual-match` and `folder visual-match`, defaulting to **100**. Visual search ranks every asset by visual similarity (there is no similarity threshold in the API), so a limit keeps the output manageable; pass a higher `--limit` to retrieve more. The client requests only as many results per page as needed, so a small limit costs a single API call.
+
 ## [1.4.0] - 2026-06-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ pcli2 asset delete           # Delete an asset
 pcli2 asset dependencies     # Get dependencies for an asset
 pcli2 asset geometric-match  # Find geometrically similar assets
 pcli2 asset part-match       # Find part matches for an asset
-pcli2 asset visual-match     # Find visually similar assets
+pcli2 asset visual-match     # Find visually similar assets (--limit N, default 100)
 pcli2 asset text-match       # Find assets using text search
 pcli2 asset reprocess        # Reprocess an asset to refresh its analysis
 pcli2 asset thumbnail        # Download asset thumbnail
@@ -666,7 +666,7 @@ pcli2 folder upload           # Upload all assets from a local directory to a Ph
 pcli2 folder dependencies     # Get dependencies for all assembly assets in folder
 pcli2 folder geometric-match  # Find geometrically similar assets for all assets in folder
 pcli2 folder part-match       # Find part matches for all assets in folder
-pcli2 folder visual-match     # Find visually similar assets for all assets in folder
+pcli2 folder visual-match     # Find visually similar assets for all assets in folder (--limit N, default 100)
 pcli2 folder thumbnail        # Download thumbnails for all assets in a folder
 ```
 

--- a/src/actions/assets/match_ops.rs
+++ b/src/actions/assets/match_ops.rs
@@ -307,6 +307,13 @@ pub async fn visual_match_asset(sub_matches: &ArgMatches) -> Result<(), CliError
     let asset_uuid_param = sub_matches.get_one::<uuid::Uuid>(PARAMETER_UUID);
     let asset_path_param = sub_matches.get_one::<String>(PARAMETER_PATH);
 
+    // Maximum number of results to return (visual search ranks every asset, so a
+    // limit is required to keep the result set manageable).
+    let limit = sub_matches
+        .get_one::<usize>(crate::commands::params::PARAMETER_LIMIT)
+        .copied()
+        .unwrap_or(100);
+
     // Use FormatParams for consistent format parameter handling
     let format_params = crate::format_utils::FormatParams::from_args(sub_matches);
     let format = format_params.format;
@@ -327,7 +334,10 @@ pub async fn visual_match_asset(sub_matches: &ArgMatches) -> Result<(), CliError
     .await?;
 
     // Perform visual search
-    let mut search_results = ctx.api().visual_search(&tenant_uuid, &asset.uuid()).await?;
+    let mut search_results = ctx
+        .api()
+        .visual_search(&tenant_uuid, &asset.uuid(), limit)
+        .await?;
 
     // Load configuration to get the UI base URL
     let configuration =
@@ -1689,6 +1699,12 @@ pub async fn visual_match_folder(sub_matches: &ArgMatches) -> Result<(), CliErro
     let with_metadata = format_params.format_options.with_metadata;
     let with_headers = format_params.format_options.with_headers;
 
+    // Maximum number of visual-search results to return per asset.
+    let limit = sub_matches
+        .get_one::<usize>(crate::commands::params::PARAMETER_LIMIT)
+        .copied()
+        .unwrap_or(100);
+
     // Get exclusive flag
     let exclusive = sub_matches.get_flag("exclusive");
 
@@ -1803,7 +1819,10 @@ pub async fn visual_match_folder(sub_matches: &ArgMatches) -> Result<(), CliErro
                 pb.set_message("Starting visual search...");
             }
 
-            let result = match api_clone.visual_search(&tenant_uuid, &asset_uuid).await {
+            let result = match api_clone
+                .visual_search(&tenant_uuid, &asset_uuid, limit)
+                .await
+            {
                 Ok(search_results) => {
                     // Update progress bar to show processing matches
                     if let Some(ref pb) = individual_pb {

--- a/src/commands/assets.rs
+++ b/src/commands/assets.rs
@@ -8,14 +8,15 @@ use crate::commands::params::{
     asset_identifier_group, asset_identifier_multiple_group, candidate_identifier_group,
     candidate_path_parameter, candidate_uuid_parameter, file_parameter, folder_identifier_group,
     folder_path_parameter, folder_uuid_parameter, format_parameter, format_pretty_parameter,
-    format_with_headers_parameter, format_with_metadata_parameter, multiple_files_parameter,
-    override_parameter, path_parameter, reference_identifier_group, reference_path_parameter,
-    reference_uuid_parameter, restore_metadata_parameter, tenant_parameter, uuid_parameter,
-    COMMAND_ASSET, COMMAND_COUNTS, COMMAND_CREATE, COMMAND_CREATE_BATCH, COMMAND_DELETE,
-    COMMAND_DEPENDENCIES, COMMAND_DOWNLOAD, COMMAND_FULL_INVENTORY, COMMAND_GET, COMMAND_LIST,
-    COMMAND_MATCH, COMMAND_PART_MATCH, COMMAND_REPROCESS, COMMAND_SIMILARITY, COMMAND_TEXT_MATCH,
-    COMMAND_THUMBNAIL, COMMAND_VISUAL_MATCH, FORMAT_CSV, FORMAT_JSON, FORMAT_TREE,
-    PARAMETER_CONCURRENT, PARAMETER_FILE, PARAMETER_FUZZY, PARAMETER_PROGRESS,
+    format_with_headers_parameter, format_with_metadata_parameter, limit_parameter,
+    multiple_files_parameter, override_parameter, path_parameter, reference_identifier_group,
+    reference_path_parameter, reference_uuid_parameter, restore_metadata_parameter,
+    tenant_parameter, uuid_parameter, COMMAND_ASSET, COMMAND_COUNTS, COMMAND_CREATE,
+    COMMAND_CREATE_BATCH, COMMAND_DELETE, COMMAND_DEPENDENCIES, COMMAND_DOWNLOAD,
+    COMMAND_FULL_INVENTORY, COMMAND_GET, COMMAND_LIST, COMMAND_MATCH, COMMAND_PART_MATCH,
+    COMMAND_REPROCESS, COMMAND_SIMILARITY, COMMAND_TEXT_MATCH, COMMAND_THUMBNAIL,
+    COMMAND_VISUAL_MATCH, FORMAT_CSV, FORMAT_JSON, FORMAT_TREE, PARAMETER_CONCURRENT,
+    PARAMETER_FILE, PARAMETER_FUZZY, PARAMETER_PROGRESS,
 };
 use clap::{Arg, ArgAction, Command};
 
@@ -200,6 +201,7 @@ pub fn asset_command() -> Command {
             .arg(tenant_parameter())
             .arg(uuid_parameter())
             .arg(path_parameter())
+            .arg(limit_parameter())
             .arg(format_with_headers_parameter())
             .arg(format_with_metadata_parameter())
             .arg(format_pretty_parameter())

--- a/src/commands/folder.rs
+++ b/src/commands/folder.rs
@@ -5,7 +5,7 @@
 use crate::commands::params::{
     folder_identifier_group, folder_path_parameter, folder_uuid_parameter, format_parameter,
     format_pretty_parameter, format_with_headers_parameter, format_with_metadata_parameter,
-    name_parameter, output_file_parameter, parent_folder_identifier_group,
+    limit_parameter, name_parameter, output_file_parameter, parent_folder_identifier_group,
     parent_folder_path_parameter, parent_folder_uuid_parameter, tenant_parameter, COMMAND_CREATE,
     COMMAND_DELETE, COMMAND_FOLDER, COMMAND_GET, COMMAND_LIST, COMMAND_MATCH, COMMAND_PART_MATCH,
     COMMAND_VISUAL_MATCH, FORMAT_CSV, FORMAT_JSON, FORMAT_XLS, PARAMETER_PROGRESS,
@@ -325,6 +325,7 @@ pub fn folder_command() -> Command {
                 .visible_alias("visual-search") // Add alias for visual-search
                 .about("Find visually similar assets for all assets in one or more folders")
                 .arg(tenant_parameter())
+                .arg(limit_parameter())
                 .arg(
                     clap::Arg::new(crate::commands::params::PARAMETER_FOLDER_PATH)
                         .short('p')

--- a/src/commands/params.rs
+++ b/src/commands/params.rs
@@ -108,6 +108,7 @@ pub const PARAMETER_RELOAD: &str = "reload";
 pub const PARAMETER_RECURSIVE: &str = "recursive";
 pub const PARAMETER_CONCURRENT: &str = "concurrent";
 pub const PARAMETER_PROGRESS: &str = "progress";
+pub const PARAMETER_LIMIT: &str = "limit";
 pub const PARAMETER_FOLDER_PATHS: &str = "folder-paths";
 pub const PARAMETER_CONTINUE_ON_ERROR: &str = "continue-on-error";
 pub const PARAMETER_DELAY: &str = "delay";
@@ -165,6 +166,20 @@ pub fn format_with_metadata_parameter() -> Arg {
         .action(ArgAction::SetTrue)
         .required(false)
         .help("Format the output to include metadata")
+}
+
+/// Create the results limit parameter (default 100).
+///
+/// Used by the visual-match commands to cap the number of returned results,
+/// since visual search returns every asset ranked by visual similarity.
+pub fn limit_parameter() -> Arg {
+    Arg::new(PARAMETER_LIMIT)
+        .long(PARAMETER_LIMIT)
+        .num_args(1)
+        .required(false)
+        .default_value("100")
+        .help("Maximum number of results to return")
+        .value_parser(clap::value_parser!(usize))
 }
 
 /// Create the global output file parameter.

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -2891,7 +2891,7 @@ impl PhysnaApiClient {
     /// # let mut client = PhysnaApiClient::new();
     /// # let tenant_uuid = Uuid::nil();
     /// # let asset_uuid = Uuid::nil();
-    /// let matches = client.visual_search(&tenant_uuid, &asset_uuid).await?;
+    /// let matches = client.visual_search(&tenant_uuid, &asset_uuid, 100).await?;
     /// for match_result in &matches.matches {
     ///     println!("Found visually similar asset: {}", match_result.path());
     /// }
@@ -2902,60 +2902,124 @@ impl PhysnaApiClient {
         &mut self,
         tenant_uuid: &Uuid,
         asset_uuid: &Uuid,
+        limit: usize,
     ) -> Result<crate::model::PartSearchResponse, ApiError> {
         debug!(
-            "Starting visual search for tenant_uuid: {}, asset_uuid: {}",
-            tenant_uuid, asset_uuid
+            "Starting visual search for tenant_uuid: {}, asset_uuid: {}, limit: {}",
+            tenant_uuid, asset_uuid, limit
         );
-        let url = format!(
+        // The visual-search endpoint takes `page` and `perPage` as QUERY
+        // parameters (unlike geometric and part search, which take them in the
+        // request body). Sending them in the body has no effect, which is why
+        // this method previously always returned only the first page (~20
+        // results) while the web UI showed the full result set. Build the base
+        // URL here and append the pagination query per page below.
+        let base_url = format!(
             "{}/tenants/{}/assets/{}/visual-search",
             self.base_url, tenant_uuid, asset_uuid
         );
 
-        // Visual search - get first page with 50 results (top matches)
-        let page = 1;
-        let per_page = 50; // Reasonable page size for visual search
+        // Accumulate matches across pages until we have at least `limit`.
+        let mut all_matches = Vec::new();
+        let mut page = 1;
+        // Request only as many per page as we need (capped at the endpoint
+        // maximum of 1000), so a small limit costs a single request.
+        let per_page = limit.clamp(1, 1000);
 
-        // Build request body with the correct structure
-        let body = serde_json::json!({
-            "page": page,
-            "perPage": per_page,
-            "searchQuery": "",
-            "filters": {
-                "folders": [],
-                "metadata": {},
-                "extensions": []  // Empty array as requested
-            }
-        });
+        // Track the maximum last_page value seen to prevent infinite loops.
+        let mut max_last_page_seen = 0;
+        let max_pages_limit = 1000; // Hard limit to prevent excessive API calls
 
-        debug!("Sending visual search request to: {}", url);
-        // Execute POST request
-        let result: Result<crate::model::PartSearchResponse, ApiError> =
-            self.post(&url, &body).await;
-
-        match result {
-            Ok(mut response) => {
-                // Limit results to 50 to ensure we don't exceed expected page size
-                if response.matches.len() > 50 {
-                    response.matches.truncate(50);
-                }
-
-                // Clear pagination data since we're only getting the first page
-                response.page_data = None;
-
+        loop {
+            // Check if we've hit the hard limit.
+            if page > max_pages_limit {
                 debug!(
-                    "Visual search completed for asset_id: {} with {} total matches",
-                    asset_uuid,
-                    response.matches.len()
+                    "Reached hard page limit of {}, stopping visual search pagination",
+                    max_pages_limit
                 );
-                Ok(response)
+                break;
             }
-            Err(e) => {
-                // Return error immediately
-                debug!("Visual search failed: {}", e);
-                Err(e)
+
+            // `page` and `perPage` are query parameters for this endpoint. The
+            // request body carries only the optional filtering.
+            let url = format!("{}?page={}&perPage={}", base_url, page, per_page);
+            let body = serde_json::json!({
+                "searchQuery": "",
+                "filters": {
+                    "folders": [],
+                    "metadata": {}
+                }
+            });
+
+            debug!("Sending visual search request to: {}", url);
+            // Execute POST request.
+            let result: Result<crate::model::PartSearchResponse, ApiError> =
+                self.post(&url, &body).await;
+
+            match result {
+                Ok(response) => {
+                    // Check if we have pagination data.
+                    if let Some(page_data) = &response.page_data {
+                        debug!(
+                            "Page {}/{} with {} total matches",
+                            page_data.current_page, page_data.last_page, page_data.total
+                        );
+
+                        // Update the maximum last_page value seen.
+                        if page_data.last_page > max_last_page_seen {
+                            max_last_page_seen = page_data.last_page;
+                        }
+
+                        // Add matches from this page to our collection.
+                        all_matches.extend(response.matches);
+
+                        // Stop once we have enough results, reach the last page,
+                        // or the endpoint fails to advance `current_page` (guard
+                        // against looping forever on the same page).
+                        if all_matches.len() >= limit
+                            || page_data.current_page >= page_data.last_page
+                            || page_data.current_page < page
+                        {
+                            break;
+                        }
+
+                        // Move to the next page.
+                        page += 1;
+                    } else {
+                        // No pagination data - return this single page, capped at
+                        // the requested limit.
+                        debug!(
+                            "No pagination data in visual search response, returning single page"
+                        );
+                        let mut response = response;
+                        response.matches.truncate(limit);
+                        return Ok(response);
+                    }
+                }
+                Err(e) => {
+                    // Return error immediately.
+                    debug!("Visual search failed: {}", e);
+                    return Err(e);
+                }
             }
         }
+
+        // The last page may overshoot the requested limit; cap it here.
+        all_matches.truncate(limit);
+
+        // Create a response with all matches aggregated across pages.
+        let final_response = crate::model::PartSearchResponse {
+            matches: all_matches,
+            page_data: None, // We've aggregated all pages
+            filter_data: None,
+        };
+
+        debug!(
+            "Visual search completed for asset_id: {} with {} total matches",
+            asset_uuid,
+            final_response.matches.len()
+        );
+        Ok(final_response)
     }
 
     /// Performs a text search for assets matching the provided text query


### PR DESCRIPTION
## Release v1.4.1

### Fixed
- **`visual-match` pagination** — visual search now returns the full ranked result set instead of only the first ~20 matches (the endpoint takes `page`/`perPage` as query params; they were being sent in the body and ignored).

### Added
- **`--limit`** (default 100) on `asset visual-match` and `folder visual-match` to cap the ranked result set.

See [CHANGELOG.md](CHANGELOG.md) for details.

### Verification
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, full test suite — all green locally
- Verified live against a tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)