### PR TITLE
Release v1.6.0: Physna UI CSV format for asset metadata create-batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-01
+
+### Added
+- **Physna UI CSV format support for `asset metadata create-batch`** - The command now accepts the horizontal CSV layout used by the Physna web UI's bulk metadata upload, in addition to the existing vertical `ASSET_PATH,NAME,VALUE` format. The layout is auto-detected from the header row (any column starting with `metadata:` selects the UI format) and can be forced with the new `--csv-format <auto|classic|ui>` option (default: `auto`).
+  - The UI format has one row per asset: a `path` column, an optional `id` column holding the asset UUID, and one `metadata:<field name>` column per metadata field (the prefix is stripped to obtain the field name).
+  - When a row's `id` is present and non-empty, the UUID **takes precedence** over the path and is used directly. An invalid UUID is an error - there is no fallback to the path, since that could silently target a different asset.
+  - **Empty metadata cells are skipped** (existing values are left untouched), unlike the classic format where an empty VALUE deletes the field. Spreadsheet-style exports naturally contain blank cells, so blanks are never treated as deletions in this layout.
+  - Columns other than `path`, `id`, and `metadata:*` are ignored with a warning. The whole file is parsed and validated (including UUID syntax) with line-numbered errors before authentication or any API call, so a malformed file fails fast instead of half-applying.
+  - The classic vertical format behavior is unchanged; existing CSV files continue to work without any flag.
+  - Affects `pcli2 asset metadata create-batch` (and its `update-batch` alias).
+
 ## [1.5.0] - 2026-07-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/README.md
+++ b/README.md
@@ -309,7 +309,8 @@ pcli2 asset metadata create --path "/Root/Models/part.stl" --name "Material" --v
 # Get all metadata for an asset
 pcli2 asset metadata get --path "/Root/Models/part.stl"
 
-# Bulk metadata update from CSV
+# Bulk metadata update from CSV (classic vertical or Physna UI horizontal
+# layout, auto-detected from the header row)
 pcli2 asset metadata create-batch --csv-file "metadata.csv"
 ```
 
@@ -677,9 +678,11 @@ pcli2 asset metadata create-batch  # Create metadata for multiple assets from a 
 pcli2 asset metadata inference     # Apply metadata from a reference asset to geometrically similar assets
 ```
 
-#### Asset Metadata Create-Batch CSV Format
+#### Asset Metadata Create-Batch CSV Formats
 
-The CSV file for `asset metadata create-batch` must have the following columns in the specified order:
+The `asset metadata create-batch` command accepts two CSV layouts. The layout is auto-detected from the header row (any column starting with `metadata:` selects the UI format), or can be forced with `--csv-format classic|ui`.
+
+**Classic (vertical) format** — one row per asset+field combination:
 
 ```
 ASSET_PATH,NAME,VALUE
@@ -689,13 +692,27 @@ ASSET_PATH,NAME,VALUE
 /Root/Folder/Model2.ipt,Supplier,Richardson Electronics
 ```
 
-**CSV File Requirements**:
 - The first row must contain the headers `ASSET_PATH,NAME,VALUE`
+- Each row represents a single metadata field assignment for an asset
+- An empty `VALUE` deletes the metadata field from the asset
+- If an asset has multiple metadata fields to update, include multiple rows with the same `ASSET_PATH` but different `NAME` and `VALUE` combinations
+
+**UI (horizontal) format** — one row per asset, as exported by the Physna web UI's bulk metadata upload:
+
+```
+path,id,metadata:Material,metadata:Color
+/Root/Folder/Model1.stl,,Steel,Blue
+/Root/Folder/Model2.ipt,123e4567-e89b-12d3-a456-426614174000,Aluminum,Red
+```
+
+- `path` is the asset path; the optional `id` column holds the asset UUID and takes precedence over the path when present
+- Each `metadata:<field name>` column sets one metadata field (the prefix is stripped)
+- Empty metadata cells are skipped (existing values are left untouched); unrecognized columns are ignored with a warning
+
+**General requirements** (both formats):
 - The file must be UTF-8 encoded
 - Values containing commas, quotes, or newlines must be enclosed in double quotes
 - Empty rows will be ignored
-- Each row represents a single metadata field assignment for an asset
-- If an asset has multiple metadata fields to update, include multiple rows with the same `ASSET_PATH` but different `NAME` and `VALUE` combinations
 
 **Error Handling**:
 

--- a/docs/src/metadata-operations.md
+++ b/docs/src/metadata-operations.md
@@ -57,9 +57,13 @@ Create or update metadata for multiple assets from a CSV file:
 pcli2 asset metadata create-batch --csv-file "metadata.csv"
 ```
 
-## CSV Format for Batch Metadata Operations
+## CSV Formats for Batch Metadata Operations
 
-The CSV format used by `asset metadata get --format csv` and `asset metadata create-batch --csv-file` is designed for seamless round-trip operations:
+The `create-batch` command accepts two CSV layouts. The layout is detected automatically from the header row: if any column name starts with `metadata:`, the file is treated as the UI (horizontal) format; otherwise it is treated as the classic (vertical) format. You can also force a layout explicitly with `--csv-format classic` or `--csv-format ui` (the default is `--csv-format auto`).
+
+### Classic (Vertical) Format
+
+The classic CSV format used by `asset metadata get --format csv` and `asset metadata create-batch --csv-file` is designed for seamless round-trip operations:
 
 ```csv
 ASSET_PATH,NAME,VALUE
@@ -99,6 +103,35 @@ ASSET_PATH,NAME,VALUE
 In the example above, `ObsoleteField` is deleted and `Material` is set to `Steel` in a single pass.
 
 **Note:** The `create-batch` command groups all rows by asset path, then issues deletes (empty values) followed by updates (non-empty values) per asset in one batch. Multiple rows with the same ASSET_PATH are combined into a single API interaction.
+
+### UI (Horizontal) Format
+
+The Physna web UI's bulk metadata upload uses a horizontal layout with one row per asset and one column per metadata field. `create-batch` accepts these files directly:
+
+```csv
+"path","id","metadata:Material","metadata:Color","metadata:Weight"
+"/domain/assets/part1.sldprt","123e4567-e89b-12d3-a456-426614174000","Steel","Blue","2.5kg"
+"/domain/assets/part2.step","","Aluminum","Red","1.2kg"
+"/domain/assets/assembly.sldasm","","Mixed","",""
+```
+
+The UI format specifications:
+- **path**: Full path to the asset in Physna
+- **id**: Optional asset UUID. When present and non-empty, it takes precedence over the path and is used directly, without path resolution. An invalid UUID is an error (there is no fallback to the path, since that could silently target a different asset)
+- **metadata:&lt;field name&gt;**: One column per metadata field. The `metadata:` prefix is stripped to obtain the field name
+- **Empty metadata cells**: Skipped — the existing field value on the asset, if any, is left untouched. (This differs from the classic format, where an empty VALUE deletes the field. Spreadsheet-style exports naturally contain blank cells for fields that don't apply, so blanks are never treated as deletions in this layout)
+- **Other columns**: Any column that is not `path`, `id`, or `metadata:*` is ignored, with a warning listing the ignored columns
+- **Row identification**: Each row must provide a UUID or a path; a row with neither is an error
+
+The whole file is parsed and validated before any API call is made, so a malformed file (e.g. an invalid UUID) fails fast with a line-numbered error instead of half-applying.
+
+```bash
+# Auto-detected from the header row
+pcli2 asset metadata create-batch --csv-file "ui-export.csv"
+
+# Or forced explicitly
+pcli2 asset metadata create-batch --csv-file "ui-export.csv" --csv-format ui
+```
 
 ## Advanced Metadata Workflow: Export, Modify, Reimport
 

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -4,6 +4,7 @@
 //! including batch operations and metadata management.
 
 use crate::{
+    actions::assets::metadata_batch_csv::{parse_batch_csv, BatchAssetRef, BatchCsvFormat},
     actions::folders::resolve_folder_uuid_by_path,
     actions::CliActionError,
     commands::params::{
@@ -354,51 +355,34 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
 
     let show_progress = sub_matches.get_flag("progress");
     let continue_on_error = sub_matches.get_flag(PARAMETER_CONTINUE_ON_ERROR);
+    let requested_format = sub_matches
+        .get_one::<String>("csv-format")
+        .map(|s| BatchCsvFormat::from_arg(s))
+        .unwrap_or(BatchCsvFormat::Auto);
+
+    // Parse and validate the whole CSV file (classic vertical or UI
+    // horizontal layout) before authenticating or making any API calls, so a
+    // malformed file fails fast instead of half-applying.
+    let file = std::fs::File::open(csv_file_path)
+        .map_err(|e| CliError::ActionError(CliActionError::IoError(e)))?;
+    let parsed = parse_batch_csv(file, requested_format).map_err(CliError::ActionError)?;
+
+    debug!("Parsed batch CSV as {:?} format", parsed.format);
+    for warning in &parsed.warnings {
+        error_utils::report_warning(warning);
+    }
+    let entries = parsed.entries;
 
     let configuration = Configuration::load_or_create_default()?;
     let mut api = PhysnaApiClient::try_default()?;
     let tenant = get_tenant(&mut api, sub_matches, &configuration).await?;
-
-    // Read the CSV file and store raw string values
-    // Structure: {asset_path: {metadata_name: raw_string_value}}
-    let mut raw_asset_metadata: HashMap<String, HashMap<String, String>> = HashMap::new();
-
-    let file = std::fs::File::open(csv_file_path)
-        .map_err(|e| CliError::ActionError(CliActionError::IoError(e)))?;
-    let mut reader = csv::Reader::from_reader(file);
-
-    for result in reader.records() {
-        let record: csv::StringRecord = result
-            .map_err(|e| CliError::FormattingError(crate::format::FormattingError::CsvError(e)))?;
-
-        if record.len() >= 3 {
-            let asset_path: &str = record[0].trim();
-            let metadata_name: &str = record[1].trim();
-            let metadata_value: &str = record[2].trim();
-
-            // Keep empty values - they mean "delete existing metadata"
-            if metadata_value.is_empty() {
-                debug!(
-                    "Empty value for metadata field '{}' on asset '{}' (will delete existing)",
-                    metadata_name, asset_path
-                );
-            }
-
-            // Group metadata by asset path (strip leading slash if present)
-            let clean_asset_path = asset_path.strip_prefix('/').unwrap_or(asset_path);
-            raw_asset_metadata
-                .entry(clean_asset_path.to_string())
-                .or_default()
-                .insert(metadata_name.to_string(), metadata_value.to_string());
-        }
-    }
 
     // Pre-flight token expiration check
     const TIME_PER_ASSET_SECONDS: u64 = 5;
     const SAFETY_MARGIN_SECONDS: u64 = 300;
 
     let time_remaining = api.get_token_time_remaining().unwrap_or(0);
-    let estimated_time_needed = (raw_asset_metadata.len() as u64) * TIME_PER_ASSET_SECONDS;
+    let estimated_time_needed = (entries.len() as u64) * TIME_PER_ASSET_SECONDS;
 
     if time_remaining > 0 && (time_remaining as u64) < estimated_time_needed + SAFETY_MARGIN_SECONDS
     {
@@ -416,7 +400,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
     let mut asset_cache = AssetMetadataCache::new();
 
     // Process each asset
-    let total_assets = raw_asset_metadata.len();
+    let total_assets = entries.len();
     let mut success_count = 0;
     let mut failure_count = 0;
     let mut skipped_missing = 0;
@@ -454,9 +438,14 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
         None => error_utils::report_warning(&msg),
     };
 
-    for (asset_path, raw_metadata) in &raw_asset_metadata {
+    for entry in &entries {
+        // Display key for progress, caching, and error messages: the asset
+        // path, or the UUID when the row identified the asset by UUID.
+        let asset_display = entry.asset.display();
+        let raw_metadata = &entry.metadata;
+
         if let Some(pb) = progress_bar.as_ref() {
-            pb.set_message(asset_path.clone());
+            pb.set_message(asset_display.clone());
             pb.inc(1);
         }
 
@@ -470,13 +459,17 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
         }
 
         // Get the asset to read existing metadata types (use cache if available)
-        let asset = match asset_cache.get(asset_path) {
+        let asset = match asset_cache.get(&asset_display) {
             Some(cached) => cached.clone(),
             None => {
-                match api.get_asset_by_path(&tenant.uuid, asset_path).await {
+                let lookup_result = match &entry.asset {
+                    BatchAssetRef::Uuid(uuid) => api.get_asset_by_uuid(&tenant.uuid, uuid).await,
+                    BatchAssetRef::Path(path) => api.get_asset_by_path(&tenant.uuid, path).await,
+                };
+                match lookup_result {
                     Ok(asset) => {
                         // Cache the asset for potential reuse
-                        asset_cache.insert(asset_path.clone(), asset.clone());
+                        asset_cache.insert(asset_display.clone(), asset.clone());
                         asset
                     }
                     Err(e) => {
@@ -487,7 +480,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                         {
                             auth_failure_occurred = true;
                             report(
-                                format!("Authentication failed while looking up asset '{}': {}", asset_path, e),
+                                format!("Authentication failed while looking up asset '{}': {}", asset_display, e),
                                 &[
                                     "Your access token may have expired",
                                     "Try running 'pcli2 auth expiration' to check token status",
@@ -505,21 +498,27 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                         // detailed guidance to one summary at the end of the run.
                         if continue_on_error {
                             skipped_missing += 1;
-                            warn(format!("Skipped '{}' — asset not found", asset_path));
+                            warn(format!("Skipped '{}' — asset not found", asset_display));
                             continue;
                         }
 
-                        report(
-                            format!("Asset not found: '{}'", asset_path),
-                            &[
+                        let remediation_steps: &[&str] = match &entry.asset {
+                            BatchAssetRef::Uuid(_) => &[
+                                "Verify the UUID in the 'id' column matches an existing asset in Physna",
+                                "Check that the asset hasn't been deleted or re-uploaded (re-uploading changes the UUID)",
+                                "Verify you're using the correct tenant for this asset",
+                                "Or re-run with --continue-on-error to skip unresolvable assets",
+                            ],
+                            BatchAssetRef::Path(_) => &[
                                 "Verify the asset path in your CSV file matches the actual asset path in Physna",
                                 "Check that the asset hasn't been deleted from the system",
                                 "Verify you're using the correct tenant for this asset",
                                 "Check for path format mismatches (e.g., leading slash differences)",
                                 "Verify the asset exists using 'pcli2 asset list --folder-path /' or similar command",
-                                "Or re-run with --continue-on-error to skip unresolved paths"
-                            ]
-                        );
+                                "Or re-run with --continue-on-error to skip unresolved paths",
+                            ],
+                        };
+                        report(format!("Asset not found: '{}'", asset_display), remediation_steps);
 
                         if let Some(pb) = progress_bar.as_ref() {
                             pb.finish_and_clear();
@@ -563,7 +562,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                     report(
                         format!(
                             "Authentication failed while deleting metadata for asset '{}': {}",
-                            asset_path, e
+                            asset_display, e
                         ),
                         &[
                             "Your access token may have expired",
@@ -577,7 +576,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                 report(
                     format!(
                         "Failed to delete metadata fields for asset '{}': {}",
-                        asset_path, e
+                        asset_display, e
                     ),
                     &[
                         "Verify the metadata field names exist on this asset",
@@ -616,7 +615,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                     report(
                         format!(
                             "Authentication failed while updating metadata for asset '{}': {}",
-                            asset_path, e
+                            asset_display, e
                         ),
                         &[
                             "Your access token may have expired",
@@ -630,7 +629,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
 
                 if error_str.contains("must be a") || error_str.contains("Metadata type mismatch") {
                     report(
-                        format!("Type conflict for asset '{}': {}", asset_path, e),
+                        format!("Type conflict for asset '{}': {}", asset_display, e),
                         &[
                             "The metadata field already exists with a different type",
                             "Delete the existing field first if you need to change its type",
@@ -641,7 +640,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                     report(
                         format!(
                             "Failed to update metadata for asset '{}': {}",
-                            asset_path, e
+                            asset_display, e
                         ),
                         &[
                             "Verify metadata field names and values are valid",
@@ -681,11 +680,11 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
     // every skipped asset, to keep the per-asset output concise.
     if skipped_missing > 0 {
         eprintln!(
-            "\n⚠️  {} asset(s) were skipped because their paths could not be resolved in this tenant.",
+            "\n⚠️  {} asset(s) were skipped because they could not be resolved in this tenant.",
             skipped_missing
         );
         eprintln!("🔧 To resolve, verify that:");
-        eprintln!("  1. The ASSET_PATH values in your CSV match the actual asset paths in Physna");
+        eprintln!("  1. The asset paths (and UUIDs, if present) in your CSV match actual assets in Physna");
         eprintln!("  2. You are targeting the correct tenant");
         eprintln!("  3. The assets have not been deleted, and paths match (e.g., leading slash)");
         eprintln!("  List existing paths with 'pcli2 asset list --folder-path /' to compare.");

--- a/src/actions/assets/metadata_batch_csv.rs
+++ b/src/actions/assets/metadata_batch_csv.rs
@@ -1,0 +1,487 @@
+//! CSV parsing for the "asset metadata create-batch" command.
+//!
+//! Two input layouts are supported:
+//!
+//! - **Classic (vertical)**: `ASSET_PATH,NAME,VALUE` — one row per asset+field
+//!   combination. An empty VALUE means "delete this metadata field".
+//! - **UI (horizontal)**: one row per asset with a `path` column, an optional
+//!   `id` column (asset UUID, takes precedence over the path when present),
+//!   and one `metadata:<field name>` column per metadata field, as exported by
+//!   the Physna web UI's bulk metadata upload. Empty metadata cells are
+//!   skipped (the existing field value, if any, is left untouched).
+//!
+//! The layout is auto-detected from the header row: if any column name starts
+//! with the `metadata:` prefix the file is treated as UI format, otherwise as
+//! classic. Detection can be overridden with the `--csv-format` argument.
+
+use crate::actions::CliActionError;
+use std::collections::HashMap;
+use std::io::Read;
+
+/// Column-name prefix that marks a metadata column in the UI format.
+pub const METADATA_COLUMN_PREFIX: &str = "metadata:";
+
+/// How an asset is identified by a batch CSV row.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum BatchAssetRef {
+    /// Asset UUID from the UI format's "id" column. Takes precedence over the
+    /// path and is never resolved via path lookup.
+    Uuid(uuid::Uuid),
+    /// Asset path (leading slash already stripped).
+    Path(String),
+}
+
+impl BatchAssetRef {
+    /// Human-readable identifier used for progress display, caching, and
+    /// error messages.
+    pub fn display(&self) -> String {
+        match self {
+            BatchAssetRef::Uuid(uuid) => uuid.to_string(),
+            BatchAssetRef::Path(path) => path.clone(),
+        }
+    }
+}
+
+/// The CSV layout requested on the command line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BatchCsvFormat {
+    /// Detect from the header row (default).
+    Auto,
+    /// Classic vertical ASSET_PATH,NAME,VALUE layout.
+    Classic,
+    /// Horizontal layout exported by the Physna UI.
+    Ui,
+}
+
+impl BatchCsvFormat {
+    pub fn from_arg(value: &str) -> Self {
+        match value {
+            "classic" => BatchCsvFormat::Classic,
+            "ui" => BatchCsvFormat::Ui,
+            _ => BatchCsvFormat::Auto,
+        }
+    }
+}
+
+/// Metadata assignments for a single asset.
+#[derive(Debug)]
+pub struct BatchEntry {
+    pub asset: BatchAssetRef,
+    /// Raw string values keyed by metadata field name. An empty string means
+    /// "delete this field" (only the classic format produces empty values;
+    /// the UI parser skips empty cells).
+    pub metadata: HashMap<String, String>,
+}
+
+/// Result of parsing a batch CSV file.
+#[derive(Debug)]
+pub struct ParsedBatch {
+    /// One entry per distinct asset, in file order. Rows referring to the
+    /// same asset are merged (later rows win on field conflicts).
+    pub entries: Vec<BatchEntry>,
+    /// Non-fatal issues (e.g. ignored columns) to surface before processing.
+    pub warnings: Vec<String>,
+    /// The layout that was actually used after auto-detection.
+    pub format: BatchCsvFormat,
+}
+
+/// Parse a batch metadata CSV from `reader`, detecting the layout if
+/// `requested` is [`BatchCsvFormat::Auto`].
+#[allow(clippy::result_large_err)]
+pub fn parse_batch_csv<R: Read>(
+    reader: R,
+    requested: BatchCsvFormat,
+) -> Result<ParsedBatch, CliActionError> {
+    let mut csv_reader = csv::Reader::from_reader(reader);
+    let headers = csv_reader.headers()?.clone();
+
+    let has_metadata_columns = headers
+        .iter()
+        .any(|h| is_metadata_column(h.trim()).is_some());
+
+    let format = match requested {
+        BatchCsvFormat::Auto => {
+            if has_metadata_columns {
+                BatchCsvFormat::Ui
+            } else {
+                BatchCsvFormat::Classic
+            }
+        }
+        explicit => explicit,
+    };
+
+    match format {
+        BatchCsvFormat::Ui => parse_ui(csv_reader, &headers),
+        _ => parse_classic(csv_reader),
+    }
+}
+
+/// Case-insensitive check for the `metadata:` prefix; returns the field name
+/// (trimmed, prefix stripped) when the header is a metadata column.
+fn is_metadata_column(header: &str) -> Option<&str> {
+    let prefix_len = METADATA_COLUMN_PREFIX.len();
+    if header.len() >= prefix_len && header[..prefix_len].eq_ignore_ascii_case(METADATA_COLUMN_PREFIX)
+    {
+        Some(header[prefix_len..].trim())
+    } else {
+        None
+    }
+}
+
+/// Accumulates entries grouped by asset reference while preserving file order.
+struct EntryAccumulator {
+    entries: Vec<BatchEntry>,
+    index_by_asset: HashMap<BatchAssetRef, usize>,
+}
+
+impl EntryAccumulator {
+    fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            index_by_asset: HashMap::new(),
+        }
+    }
+
+    fn add(&mut self, asset: BatchAssetRef, field: String, value: String) {
+        let index = *self.index_by_asset.entry(asset.clone()).or_insert_with(|| {
+            self.entries.push(BatchEntry {
+                asset,
+                metadata: HashMap::new(),
+            });
+            self.entries.len() - 1
+        });
+        self.entries[index].metadata.insert(field, value);
+    }
+}
+
+/// Parse the classic vertical ASSET_PATH,NAME,VALUE layout.
+#[allow(clippy::result_large_err)]
+fn parse_classic<R: Read>(mut csv_reader: csv::Reader<R>) -> Result<ParsedBatch, CliActionError> {
+    let mut accumulator = EntryAccumulator::new();
+
+    for result in csv_reader.records() {
+        let record = result?;
+        if record.len() >= 3 {
+            let asset_path = record[0].trim();
+            let metadata_name = record[1].trim();
+            let metadata_value = record[2].trim();
+
+            // Empty values are kept - they mean "delete existing metadata"
+            let clean_asset_path = asset_path.strip_prefix('/').unwrap_or(asset_path);
+            accumulator.add(
+                BatchAssetRef::Path(clean_asset_path.to_string()),
+                metadata_name.to_string(),
+                metadata_value.to_string(),
+            );
+        }
+    }
+
+    Ok(ParsedBatch {
+        entries: accumulator.entries,
+        warnings: Vec::new(),
+        format: BatchCsvFormat::Classic,
+    })
+}
+
+/// Parse the horizontal layout exported by the Physna UI.
+#[allow(clippy::result_large_err)]
+fn parse_ui<R: Read>(
+    mut csv_reader: csv::Reader<R>,
+    headers: &csv::StringRecord,
+) -> Result<ParsedBatch, CliActionError> {
+    let mut warnings: Vec<String> = Vec::new();
+    let mut path_column: Option<usize> = None;
+    let mut id_column: Option<usize> = None;
+    let mut metadata_columns: Vec<(usize, String)> = Vec::new();
+    let mut ignored_columns: Vec<String> = Vec::new();
+
+    for (index, header) in headers.iter().enumerate() {
+        let header = header.trim();
+        if let Some(field_name) = is_metadata_column(header) {
+            if field_name.is_empty() {
+                warnings.push(format!(
+                    "Column {} ('{}') has an empty metadata field name and will be ignored",
+                    index + 1,
+                    header
+                ));
+            } else {
+                metadata_columns.push((index, field_name.to_string()));
+            }
+        } else if header.eq_ignore_ascii_case("path") {
+            path_column = Some(index);
+        } else if header.eq_ignore_ascii_case("id") {
+            id_column = Some(index);
+        } else {
+            ignored_columns.push(header.to_string());
+        }
+    }
+
+    if !ignored_columns.is_empty() {
+        warnings.push(format!(
+            "Ignoring unrecognized column(s): {} (metadata columns must be prefixed with '{}')",
+            ignored_columns.join(", "),
+            METADATA_COLUMN_PREFIX
+        ));
+    }
+
+    if path_column.is_none() && id_column.is_none() {
+        return Err(CliActionError::BusinessLogicError(
+            "UI-format CSV must contain a 'path' or 'id' column identifying each asset"
+                .to_string(),
+        ));
+    }
+
+    if metadata_columns.is_empty() {
+        return Err(CliActionError::BusinessLogicError(format!(
+            "UI-format CSV must contain at least one metadata column (a column name prefixed with '{}')",
+            METADATA_COLUMN_PREFIX
+        )));
+    }
+
+    let mut accumulator = EntryAccumulator::new();
+
+    for result in csv_reader.records() {
+        let record = result?;
+        let line = record
+            .position()
+            .map(|p| p.line().to_string())
+            .unwrap_or_else(|| "?".to_string());
+
+        let id_value = id_column
+            .and_then(|i| record.get(i))
+            .map(str::trim)
+            .unwrap_or("");
+        let path_value = path_column
+            .and_then(|i| record.get(i))
+            .map(str::trim)
+            .unwrap_or("");
+
+        // UUID takes precedence over the path; an invalid UUID is an error
+        // rather than a fallback to the path, because falling back could
+        // silently target a different asset than the one intended.
+        let asset = if !id_value.is_empty() {
+            let uuid = uuid::Uuid::parse_str(id_value).map_err(|e| {
+                CliActionError::BusinessLogicError(format!(
+                    "Line {}: invalid UUID '{}' in 'id' column: {}",
+                    line, id_value, e
+                ))
+            })?;
+            BatchAssetRef::Uuid(uuid)
+        } else if !path_value.is_empty() {
+            let clean_path = path_value.strip_prefix('/').unwrap_or(path_value);
+            BatchAssetRef::Path(clean_path.to_string())
+        } else {
+            return Err(CliActionError::BusinessLogicError(format!(
+                "Line {}: row has neither an 'id' nor a 'path' value to identify the asset",
+                line
+            )));
+        };
+
+        let mut row_has_values = false;
+        for (index, field_name) in &metadata_columns {
+            let value = record.get(*index).map(str::trim).unwrap_or("");
+            // Empty cells mean "no value for this asset" and are skipped,
+            // unlike the classic format where an empty VALUE deletes the field.
+            if !value.is_empty() {
+                accumulator.add(asset.clone(), field_name.clone(), value.to_string());
+                row_has_values = true;
+            }
+        }
+
+        if !row_has_values {
+            warnings.push(format!(
+                "Line {}: no metadata values for asset '{}'; row skipped",
+                line,
+                asset.display()
+            ));
+        }
+    }
+
+    Ok(ParsedBatch {
+        entries: accumulator.entries,
+        warnings,
+        format: BatchCsvFormat::Ui,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::result_large_err)]
+    fn parse(content: &str, format: BatchCsvFormat) -> Result<ParsedBatch, CliActionError> {
+        parse_batch_csv(content.as_bytes(), format)
+    }
+
+    #[test]
+    fn auto_detects_classic_format() {
+        let csv = "ASSET_PATH,NAME,VALUE\n\
+                   folder/a.stl,Material,Steel\n\
+                   folder/a.stl,Weight,15.5 kg\n\
+                   /folder/b.stl,Material,Aluminum\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        assert_eq!(parsed.format, BatchCsvFormat::Classic);
+        assert_eq!(parsed.entries.len(), 2);
+        let a = &parsed.entries[0];
+        assert_eq!(a.asset, BatchAssetRef::Path("folder/a.stl".to_string()));
+        assert_eq!(a.metadata.get("Material").unwrap(), "Steel");
+        assert_eq!(a.metadata.get("Weight").unwrap(), "15.5 kg");
+        // Leading slash is stripped
+        let b = &parsed.entries[1];
+        assert_eq!(b.asset, BatchAssetRef::Path("folder/b.stl".to_string()));
+    }
+
+    #[test]
+    fn classic_keeps_empty_values_for_deletion() {
+        let csv = "ASSET_PATH,NAME,VALUE\n\
+                   folder/a.stl,Material,\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        assert_eq!(parsed.entries[0].metadata.get("Material").unwrap(), "");
+    }
+
+    #[test]
+    fn auto_detects_ui_format() {
+        let csv = "\"path\",\"id\",\"metadata:Material\",\"metadata:Color\"\n\
+                   \"/domain/part1.sldprt\",\"\",\"Steel\",\"Blue\"\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        assert_eq!(parsed.format, BatchCsvFormat::Ui);
+        assert_eq!(parsed.entries.len(), 1);
+        let entry = &parsed.entries[0];
+        assert_eq!(
+            entry.asset,
+            BatchAssetRef::Path("domain/part1.sldprt".to_string())
+        );
+        assert_eq!(entry.metadata.get("Material").unwrap(), "Steel");
+        assert_eq!(entry.metadata.get("Color").unwrap(), "Blue");
+    }
+
+    #[test]
+    fn ui_uuid_takes_precedence_over_path() {
+        let uuid = "123e4567-e89b-12d3-a456-426614174000";
+        let csv = format!(
+            "path,id,metadata:Material\n\
+             /domain/part1.sldprt,{},Steel\n",
+            uuid
+        );
+        let parsed = parse(&csv, BatchCsvFormat::Auto).unwrap();
+        assert_eq!(
+            parsed.entries[0].asset,
+            BatchAssetRef::Uuid(uuid::Uuid::parse_str(uuid).unwrap())
+        );
+    }
+
+    #[test]
+    fn ui_invalid_uuid_is_an_error() {
+        let csv = "path,id,metadata:Material\n\
+                   /domain/part1.sldprt,12345-67890,Steel\n";
+        let error = parse(csv, BatchCsvFormat::Auto).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("invalid UUID"), "got: {}", message);
+        assert!(message.contains("Line 2"), "got: {}", message);
+    }
+
+    #[test]
+    fn ui_empty_cells_are_skipped_not_deleted() {
+        let csv = "path,id,metadata:Material,metadata:Color,metadata:Weight\n\
+                   /domain/assembly.sldasm,,Mixed,,\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        let entry = &parsed.entries[0];
+        assert_eq!(entry.metadata.len(), 1);
+        assert_eq!(entry.metadata.get("Material").unwrap(), "Mixed");
+    }
+
+    #[test]
+    fn ui_row_with_no_identifier_is_an_error() {
+        let csv = "path,id,metadata:Material\n\
+                   ,,Steel\n";
+        let error = parse(csv, BatchCsvFormat::Auto).unwrap_err();
+        assert!(error.to_string().contains("neither an 'id' nor a 'path'"));
+    }
+
+    #[test]
+    fn ui_unknown_columns_are_warned_and_ignored() {
+        let csv = "path,id,name,metadata:Material\n\
+                   /domain/part1.sldprt,,Part One,Steel\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        assert!(parsed
+            .warnings
+            .iter()
+            .any(|w| w.contains("unrecognized column") && w.contains("name")));
+        let entry = &parsed.entries[0];
+        assert_eq!(entry.metadata.len(), 1);
+        assert!(entry.metadata.contains_key("Material"));
+    }
+
+    #[test]
+    fn ui_without_identifier_column_is_an_error() {
+        let csv = "metadata:Material\nSteel\n";
+        let error = parse(csv, BatchCsvFormat::Auto).unwrap_err();
+        assert!(error.to_string().contains("'path' or 'id' column"));
+    }
+
+    #[test]
+    fn forced_ui_without_metadata_columns_is_an_error() {
+        let csv = "path,id\n/domain/part1.sldprt,\n";
+        let error = parse(csv, BatchCsvFormat::Ui).unwrap_err();
+        assert!(error.to_string().contains("at least one metadata column"));
+    }
+
+    #[test]
+    fn forced_classic_ignores_metadata_prefix() {
+        // A file that would auto-detect as UI is parsed positionally when
+        // classic is forced.
+        let csv = "ASSET_PATH,NAME,metadata:VALUE\n\
+                   folder/a.stl,Material,Steel\n";
+        let parsed = parse(csv, BatchCsvFormat::Classic).unwrap();
+        assert_eq!(parsed.format, BatchCsvFormat::Classic);
+        assert_eq!(parsed.entries[0].metadata.get("Material").unwrap(), "Steel");
+    }
+
+    #[test]
+    fn ui_duplicate_asset_rows_are_merged() {
+        let csv = "path,id,metadata:Material,metadata:Color\n\
+                   /domain/part1.sldprt,,Steel,\n\
+                   /domain/part1.sldprt,,,Blue\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        assert_eq!(parsed.entries.len(), 1);
+        let entry = &parsed.entries[0];
+        assert_eq!(entry.metadata.get("Material").unwrap(), "Steel");
+        assert_eq!(entry.metadata.get("Color").unwrap(), "Blue");
+    }
+
+    #[test]
+    fn ui_metadata_prefix_is_case_insensitive() {
+        let csv = "path,id,Metadata:Material\n\
+                   /domain/part1.sldprt,,Steel\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        assert_eq!(parsed.format, BatchCsvFormat::Ui);
+        assert!(parsed.entries[0].metadata.contains_key("Material"));
+    }
+
+    #[test]
+    fn ui_row_with_all_empty_metadata_warns_and_skips() {
+        let csv = "path,id,metadata:Material\n\
+                   /domain/part1.sldprt,,\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        assert!(parsed.entries.is_empty());
+        assert!(parsed.warnings.iter().any(|w| w.contains("row skipped")));
+    }
+
+    #[test]
+    fn sample_template_file_shape_parses() {
+        // Mirrors data/horizontal-metadata/metadata-template.csv but with a
+        // valid UUID in the id column.
+        let csv = "\"path\",\"id\",\"metadata:Material\",\"metadata:Color\",\"metadata:Weight\"\n\
+                   \"/domain/assets/part1.sldprt\",\"123e4567-e89b-12d3-a456-426614174000\",\"Steel\",\"Blue\",\"2.5kg\"\n\
+                   \"/domain/assets/part2.step\",\"\",\"Aluminum\",\"Red\",\"1.2kg\"\n\
+                   \"/domain/assets/assembly.sldasm\",\"\",\"Mixed\",\"\",\"\"\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        assert_eq!(parsed.entries.len(), 3);
+        assert!(matches!(parsed.entries[0].asset, BatchAssetRef::Uuid(_)));
+        assert_eq!(
+            parsed.entries[1].asset,
+            BatchAssetRef::Path("domain/assets/part2.step".to_string())
+        );
+        assert_eq!(parsed.entries[2].metadata.len(), 1);
+    }
+}

--- a/src/actions/assets/mod.rs
+++ b/src/actions/assets/mod.rs
@@ -17,6 +17,7 @@ pub mod full_inventory;
 pub mod list;
 pub mod match_ops;
 pub mod metadata;
+pub mod metadata_batch_csv;
 pub mod print;
 pub mod reprocess;
 pub mod similarity;

--- a/src/commands/metadata.rs
+++ b/src/commands/metadata.rs
@@ -102,28 +102,40 @@ pub fn metadata_command() -> Command {
                 .visible_alias("update-batch")
                 .long_about(
                     "Create metadata for multiple assets from a CSV file.\n\n\
-                    The CSV file must have the following columns in the specified order:\n\
+                    Two CSV layouts are supported. The layout is detected automatically \
+                    from the header row, or can be forced with --csv-format.\n\n\
+                    CLASSIC (vertical) format — one row per asset+field combination:\n\
                     - ASSET_PATH: The full path of the asset in Physna\n\
                     - NAME: The name of the metadata field to set\n\
                     - VALUE: The value to set for the metadata field\n\n\
-                    CSV File Requirements:\n\
-                    - The first row must contain the headers ASSET_PATH,NAME,VALUE\n\
-                    - The file must be UTF-8 encoded\n\
-                    - Values containing commas, quotes, or newlines must be enclosed in double quotes\n\
-                    - Empty rows will be ignored\n\
-                    - Each row represents a single metadata field assignment for an asset\n\n\
                     If an asset has multiple metadata fields to update, include multiple rows \n\
-                    with the same ASSET_PATH but different NAME and VALUE combinations.\n\n\
-                    Example CSV format:\n\
+                    with the same ASSET_PATH but different NAME and VALUE combinations. \
+                    An empty VALUE deletes the metadata field from the asset.\n\n\
+                    Example:\n\
                     ASSET_PATH,NAME,VALUE\n\
                     folder/subfolder/asset1.stl,Material,Steel\n\
                     folder/subfolder/asset1.stl,Weight,\"15.5 kg\"\n\
                     folder/subfolder/asset2.ipt,Material,Aluminum\n\n\
-                    The command will group metadata by asset path and update all metadata \
+                    UI (horizontal) format — one row per asset, as exported by the Physna \
+                    web UI's bulk metadata upload:\n\
+                    - path: The full path of the asset in Physna\n\
+                    - id: Optional asset UUID; when present it takes precedence over the path\n\
+                    - metadata:<field name>: One column per metadata field to set\n\n\
+                    Empty metadata cells are skipped (the existing value is left untouched). \
+                    Columns other than path, id, and metadata:* are ignored with a warning.\n\n\
+                    Example:\n\
+                    path,id,metadata:Material,metadata:Color\n\
+                    /folder/part1.sldprt,,Steel,Blue\n\
+                    /folder/part2.step,123e4567-e89b-12d3-a456-426614174000,Aluminum,Red\n\n\
+                    General CSV requirements:\n\
+                    - The first row must contain the column headers\n\
+                    - The file must be UTF-8 encoded\n\
+                    - Values containing commas, quotes, or newlines must be enclosed in double quotes\n\n\
+                    The command groups metadata by asset and updates all metadata \
                     for each asset in a single API call.\n\n\
-                    By default, any error (such as an asset path that cannot be resolved \
+                    By default, any error (such as an asset that cannot be resolved \
                     or a failed metadata API call) terminates the batch operation. \
-                    Pass --continue-on-error to skip assets whose paths cannot be resolved \
+                    Pass --continue-on-error to skip assets that cannot be resolved \
                     and continue with the remaining rows. Metadata API errors always \
                     terminate execution regardless of this flag, because the API already \
                     retries transient failures internally."
@@ -136,6 +148,19 @@ pub fn metadata_command() -> Command {
                         .required(true)
                         .help("Path to the CSV file containing metadata entries")
                         .value_parser(clap::value_parser!(std::path::PathBuf)),
+                )
+                .arg(
+                    Arg::new("csv-format")
+                        .long("csv-format")
+                        .num_args(1)
+                        .required(false)
+                        .value_parser(["auto", "classic", "ui"])
+                        .default_value("auto")
+                        .help(
+                            "CSV layout: 'classic' (ASSET_PATH,NAME,VALUE rows), 'ui' (one row \
+                            per asset with 'metadata:' columns, as exported by the Physna UI), \
+                            or 'auto' to detect from the header row",
+                        ),
                 )
                 .arg(
                     Arg::new("progress")


### PR DESCRIPTION
## Summary

- `asset metadata create-batch` now accepts the horizontal CSV layout used by the Physna web UI's bulk metadata upload, in addition to the existing vertical `ASSET_PATH,NAME,VALUE` format
- The layout is auto-detected from the header row (any column starting with `metadata:` selects the UI format) and can be forced with the new `--csv-format <auto|classic|ui>` option
- In the UI format: a non-empty `id` (asset UUID) takes precedence over the `path` column with no fallback; empty metadata cells are skipped rather than treated as deletions; unrecognized columns are ignored with a warning
- The whole file is parsed and validated (with line-numbered errors) before authentication or any API call
- Classic format behavior is unchanged; existing CSV files work without any flag
- Bumps version to 1.6.0

## Test plan

- 15 new unit tests covering format detection, both parsers, UUID precedence, invalid UUIDs, empty-cell skipping, unknown columns, and duplicate-row merging
- Full test suite and `cargo clippy --all-targets -- -D warnings` pass
- Verified end-to-end against a real tenant with a UI-exported CSV: metadata applied via path resolution, empty cells left existing fields untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)