### PR TITLE
style: apply cargo fmt to metadata batch CSV code

### DIFF
--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -518,7 +518,10 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                                 "Or re-run with --continue-on-error to skip unresolved paths",
                             ],
                         };
-                        report(format!("Asset not found: '{}'", asset_display), remediation_steps);
+                        report(
+                            format!("Asset not found: '{}'", asset_display),
+                            remediation_steps,
+                        );
 
                         if let Some(pb) = progress_bar.as_ref() {
                             pb.finish_and_clear();

--- a/src/actions/assets/metadata_batch_csv.rs
+++ b/src/actions/assets/metadata_batch_csv.rs
@@ -120,7 +120,8 @@ pub fn parse_batch_csv<R: Read>(
 /// (trimmed, prefix stripped) when the header is a metadata column.
 fn is_metadata_column(header: &str) -> Option<&str> {
     let prefix_len = METADATA_COLUMN_PREFIX.len();
-    if header.len() >= prefix_len && header[..prefix_len].eq_ignore_ascii_case(METADATA_COLUMN_PREFIX)
+    if header.len() >= prefix_len
+        && header[..prefix_len].eq_ignore_ascii_case(METADATA_COLUMN_PREFIX)
     {
         Some(header[prefix_len..].trim())
     } else {
@@ -226,8 +227,7 @@ fn parse_ui<R: Read>(
 
     if path_column.is_none() && id_column.is_none() {
         return Err(CliActionError::BusinessLogicError(
-            "UI-format CSV must contain a 'path' or 'id' column identifying each asset"
-                .to_string(),
+            "UI-format CSV must contain a 'path' or 'id' column identifying each asset".to_string(),
         ));
     }
 


### PR DESCRIPTION
Fixes the `fmt` job failure on main from PR #48 — the new metadata batch CSV code had not been run through `cargo fmt`. Formatting-only change; no functional difference from the v1.6.0 release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)