### PR TITLE
Release v1.7.0: visual search endpoint migration and --threshold option

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # Format check
@@ -84,7 +83,7 @@ jobs:
     - name: Generate coverage report
       run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         files: lcov.info
         fail_ci_if_error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-07-01
+
+### Added
+- **`--threshold` option for visual match commands** - `asset visual-match` and `folder visual-match` now accept `--threshold` (short `-s`, default `80.0`), consistent with `geometric-match` and `part-match`. For visual search the value maps to the API's `sizeThreshold`: it filters matches by geometric size relative to the reference asset (higher is stricter; `0` disables size filtering).
+
+### Changed
+- **Visual search migrated to the new Physna API endpoint** - `asset visual-match` and `folder visual-match` now call `POST /tenants/assets/visual-search` (operation `CrossTenantVisualSearch`) instead of the soon-to-be-deprecated `POST /tenants/{tenantId}/assets/{assetId}/visual-search`. All inputs, including pagination, are carried in the request body; the search remains within the current tenant (the same tenant is passed as both the asset owner and the search target). The response format and command output are unchanged.
+
 ## [1.6.0] - 2026-07-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ pcli2 asset dependencies     # Get dependencies for an asset
 pcli2 asset dependency-diff  # Diff the dependency trees of two assets
 pcli2 asset geometric-match  # Find geometrically similar assets
 pcli2 asset part-match       # Find part matches for an asset
-pcli2 asset visual-match     # Find visually similar assets (--limit N, default 100)
+pcli2 asset visual-match     # Find visually similar assets (--limit N, default 100; --threshold N size filter, default 80)
 pcli2 asset text-match       # Find assets using text search
 pcli2 asset reprocess        # Reprocess an asset to refresh its analysis
 pcli2 asset thumbnail        # Download asset thumbnail
@@ -735,7 +735,7 @@ pcli2 folder upload           # Upload all assets from a local directory to a Ph
 pcli2 folder dependencies     # Get dependencies for all assembly assets in folder
 pcli2 folder geometric-match  # Find geometrically similar assets for all assets in folder
 pcli2 folder part-match       # Find part matches for all assets in folder
-pcli2 folder visual-match     # Find visually similar assets for all assets in folder (--limit N, default 100)
+pcli2 folder visual-match     # Find visually similar assets for all assets in folder (--limit N, default 100; --threshold N size filter, default 80)
 pcli2 folder thumbnail        # Download thumbnails for all assets in a folder
 ```
 

--- a/src/actions/assets/match_ops.rs
+++ b/src/actions/assets/match_ops.rs
@@ -314,6 +314,12 @@ pub async fn visual_match_asset(sub_matches: &ArgMatches) -> Result<(), CliError
         .copied()
         .unwrap_or(100);
 
+    // Get size threshold parameter
+    let threshold = sub_matches
+        .get_one::<f64>("threshold")
+        .copied()
+        .unwrap_or(80.0);
+
     // Use FormatParams for consistent format parameter handling
     let format_params = crate::format_utils::FormatParams::from_args(sub_matches);
     let format = format_params.format;
@@ -336,7 +342,7 @@ pub async fn visual_match_asset(sub_matches: &ArgMatches) -> Result<(), CliError
     // Perform visual search
     let mut search_results = ctx
         .api()
-        .visual_search(&tenant_uuid, &asset.uuid(), limit)
+        .visual_search(&tenant_uuid, &asset.uuid(), limit, threshold)
         .await?;
 
     // Load configuration to get the UI base URL
@@ -1705,6 +1711,12 @@ pub async fn visual_match_folder(sub_matches: &ArgMatches) -> Result<(), CliErro
         .copied()
         .unwrap_or(100);
 
+    // Get size threshold parameter
+    let threshold = sub_matches
+        .get_one::<f64>("threshold")
+        .copied()
+        .unwrap_or(80.0);
+
     // Get exclusive flag
     let exclusive = sub_matches.get_flag("exclusive");
 
@@ -1820,7 +1832,7 @@ pub async fn visual_match_folder(sub_matches: &ArgMatches) -> Result<(), CliErro
             }
 
             let result = match api_clone
-                .visual_search(&tenant_uuid, &asset_uuid, limit)
+                .visual_search(&tenant_uuid, &asset_uuid, limit, threshold)
                 .await
             {
                 Ok(search_results) => {

--- a/src/commands/assets.rs
+++ b/src/commands/assets.rs
@@ -218,6 +218,16 @@ pub fn asset_command() -> Command {
             .arg(uuid_parameter())
             .arg(path_parameter())
             .arg(limit_parameter())
+            .arg(
+                Arg::new("threshold")
+                    .short('s')
+                    .long("threshold")
+                    .num_args(1)
+                    .required(false)
+                    .default_value("80.0")
+                    .help("Size threshold (0.00 to 100.00): filters matches by geometric size relative to the reference asset; higher is stricter, 0 disables size filtering")
+                    .value_parser(clap::value_parser!(f64)),
+            )
             .arg(format_with_headers_parameter())
             .arg(format_with_metadata_parameter())
             .arg(format_pretty_parameter())

--- a/src/commands/folder.rs
+++ b/src/commands/folder.rs
@@ -327,6 +327,16 @@ pub fn folder_command() -> Command {
                 .arg(tenant_parameter())
                 .arg(limit_parameter())
                 .arg(
+                    clap::Arg::new("threshold")
+                        .short('s')
+                        .long("threshold")
+                        .num_args(1)
+                        .required(false)
+                        .default_value("80.0")
+                        .help("Size threshold (0.00 to 100.00): filters matches by geometric size relative to the reference asset; higher is stricter, 0 disables size filtering")
+                        .value_parser(clap::value_parser!(f64)),
+                )
+                .arg(
                     clap::Arg::new(crate::commands::params::PARAMETER_FOLDER_PATH)
                         .short('p')
                         .long(crate::commands::params::PARAMETER_FOLDER_PATH)

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -2872,10 +2872,22 @@ impl PhysnaApiClient {
     /// This method performs a visual search to find assets that are visually similar to the provided asset.
     /// The search results are ordered by relevance as determined by the visual search algorithm.
     ///
+    /// It uses the `/tenants/assets/visual-search` endpoint (operation
+    /// `CrossTenantVisualSearch`), which supersedes the deprecated
+    /// `/tenants/{tenantId}/assets/{assetId}/visual-search` endpoint. All
+    /// inputs, including pagination, are carried in the request body. The
+    /// search is performed within a single tenant by passing the same tenant
+    /// UUID as both `assetTenantId` and `searchTenantId`.
+    ///
     /// # Arguments
     ///
-    /// * `tenant_uuid` - The UUID of the tenant to search within
+    /// * `tenant_uuid` - The UUID of the tenant that owns the reference asset and is searched for matches
     /// * `asset_uuid` - The UUID of the reference asset to search for visually similar matches
+    /// * `limit` - Maximum number of matches to return
+    /// * `threshold` - Size threshold percentage (0.00 to 100.00) controlling how strictly
+    ///   matches are filtered by geometric size relative to the reference asset.
+    ///   Higher values are stricter (90 means within ±10% of the reference size);
+    ///   0 disables size filtering entirely
     ///
     /// # Returns
     ///
@@ -2891,7 +2903,7 @@ impl PhysnaApiClient {
     /// # let mut client = PhysnaApiClient::new();
     /// # let tenant_uuid = Uuid::nil();
     /// # let asset_uuid = Uuid::nil();
-    /// let matches = client.visual_search(&tenant_uuid, &asset_uuid, 100).await?;
+    /// let matches = client.visual_search(&tenant_uuid, &asset_uuid, 100, 80.0).await?;
     /// for match_result in &matches.matches {
     ///     println!("Found visually similar asset: {}", match_result.path());
     /// }
@@ -2903,21 +2915,13 @@ impl PhysnaApiClient {
         tenant_uuid: &Uuid,
         asset_uuid: &Uuid,
         limit: usize,
+        threshold: f64,
     ) -> Result<crate::model::PartSearchResponse, ApiError> {
         debug!(
-            "Starting visual search for tenant_uuid: {}, asset_uuid: {}, limit: {}",
-            tenant_uuid, asset_uuid, limit
+            "Starting visual search for tenant_uuid: {}, asset_uuid: {}, limit: {}, threshold: {}",
+            tenant_uuid, asset_uuid, limit, threshold
         );
-        // The visual-search endpoint takes `page` and `perPage` as QUERY
-        // parameters (unlike geometric and part search, which take them in the
-        // request body). Sending them in the body has no effect, which is why
-        // this method previously always returned only the first page (~20
-        // results) while the web UI showed the full result set. Build the base
-        // URL here and append the pagination query per page below.
-        let base_url = format!(
-            "{}/tenants/{}/assets/{}/visual-search",
-            self.base_url, tenant_uuid, asset_uuid
-        );
+        let url = format!("{}/tenants/assets/visual-search", self.base_url);
 
         // Accumulate matches across pages until we have at least `limit`.
         let mut all_matches = Vec::new();
@@ -2940,15 +2944,18 @@ impl PhysnaApiClient {
                 break;
             }
 
-            // `page` and `perPage` are query parameters for this endpoint. The
-            // request body carries only the optional filtering.
-            let url = format!("{}?page={}&perPage={}", base_url, page, per_page);
+            // Unlike the deprecated per-asset endpoint (which took pagination
+            // as query parameters), this endpoint carries everything in the
+            // request body, including the asset/tenant identifiers. The
+            // optional `filters` object is omitted entirely.
             let body = serde_json::json!({
+                "page": page,
+                "perPage": per_page,
                 "searchQuery": "",
-                "filters": {
-                    "folders": [],
-                    "metadata": {}
-                }
+                "assetId": asset_uuid,
+                "assetTenantId": tenant_uuid,
+                "searchTenantId": tenant_uuid,
+                "sizeThreshold": threshold
             });
 
             debug!("Sending visual search request to: {}", url);


### PR DESCRIPTION
## Summary

- **Visual search migrated to the new Physna API endpoint**: `asset visual-match` and `folder visual-match` now call `POST /tenants/assets/visual-search` (CrossTenantVisualSearch) instead of the soon-to-be-deprecated `POST /tenants/{tenantId}/assets/{assetId}/visual-search`. All inputs, including pagination, move into the request body; the search remains within the current tenant. Response format and command output are unchanged.
- **New `--threshold` option** (`-s`, default `80.0`) on both visual match commands, consistent with `geometric-match`/`part-match`. Maps to the API's `sizeThreshold`: filters matches by geometric size relative to the reference asset (higher is stricter, `0` disables size filtering).
- **CI**: bump `codecov/codecov-action` v5 → v7 to silence the Node.js 20 deprecation warning in the coverage job (v6 was the Node 24 bump; inputs unchanged).
- Bumps version to 1.7.0.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full test suite (incl. updated doc-test) pass
- Live verification against a real tenant: threshold demonstrably drives server-side filtering (1000 matches at 0, 767 at 80, 6 at 100 for the same reference asset)
- A/B comparison old vs new endpoint on a folder of 60+ assets: identical result rows and identical failure set

🤖 Generated with [Claude Code](https://claude.com/claude-code)