### PR TITLE
Release v1.8.0: --delete-if-empty flag for asset metadata create-batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`--delete-if-empty` flag for `asset metadata create-batch`** - Gives precise control over what an empty value in the input CSV means, in both the classic and UI layouts (default: `false`).
+  - **Without the flag**, empty values are skipped: the existing metadata field on the asset, if any, is left untouched, so a sparse file can be used to incrementally add or update fields. Skipped classic-format rows are reported with a single aggregate warning that points at the flag.
+  - **With the flag**, an empty value deletes that metadata field from the asset - useful for replacing an asset's metadata wholesale. This also brings the UI format to parity with the classic format: empty `metadata:` cells (including rows whose cells are all empty) become deletions, whereas previously the UI format could not delete at all.
+  - Affects `pcli2 asset metadata create-batch` (and its `update-batch` alias).
+
+### Changed
+- **Empty values in classic-format batch metadata CSVs no longer delete by default** - Previously an empty `VALUE` in the classic `ASSET_PATH,NAME,VALUE` layout always deleted the metadata field. Deletion is now opt-in via `--delete-if-empty`; without it, empty values are skipped with a warning.
+
 ## [1.7.0] - 2026-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-07-02
+
 ### Added
 - **`--delete-if-empty` flag for `asset metadata create-batch`** - Gives precise control over what an empty value in the input CSV means, in both the classic and UI layouts (default: `false`).
   - **Without the flag**, empty values are skipped: the existing metadata field on the asset, if any, is left untouched, so a sparse file can be used to incrementally add or update fields. Skipped classic-format rows are reported with a single aggregate warning that points at the flag.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/README.md
+++ b/README.md
@@ -694,7 +694,6 @@ ASSET_PATH,NAME,VALUE
 
 - The first row must contain the headers `ASSET_PATH,NAME,VALUE`
 - Each row represents a single metadata field assignment for an asset
-- An empty `VALUE` deletes the metadata field from the asset
 - If an asset has multiple metadata fields to update, include multiple rows with the same `ASSET_PATH` but different `NAME` and `VALUE` combinations
 
 **UI (horizontal) format** — one row per asset, as exported by the Physna web UI's bulk metadata upload:
@@ -707,7 +706,9 @@ path,id,metadata:Material,metadata:Color
 
 - `path` is the asset path; the optional `id` column holds the asset UUID and takes precedence over the path when present
 - Each `metadata:<field name>` column sets one metadata field (the prefix is stripped)
-- Empty metadata cells are skipped (existing values are left untouched); unrecognized columns are ignored with a warning
+- Unrecognized columns are ignored with a warning
+
+In both formats, empty values are skipped by default (existing metadata is left untouched). Pass `--delete-if-empty` to instead delete a metadata field from the asset when the file contains an empty value for it.
 
 **General requirements** (both formats):
 - The file must be UTF-8 encoded

--- a/docs/src/metadata-operations.md
+++ b/docs/src/metadata-operations.md
@@ -61,6 +61,8 @@ pcli2 asset metadata create-batch --csv-file "metadata.csv"
 
 The `create-batch` command accepts two CSV layouts. The layout is detected automatically from the header row: if any column name starts with `metadata:`, the file is treated as the UI (horizontal) format; otherwise it is treated as the classic (vertical) format. You can also force a layout explicitly with `--csv-format classic` or `--csv-format ui` (the default is `--csv-format auto`).
 
+In both layouts, **empty values are skipped by default**: the existing metadata field on the asset, if any, is left untouched, so a sparse file can be used to incrementally add or update fields. Pass `--delete-if-empty` to instead **delete** a metadata field from the asset when the file contains an empty value for it — useful when replacing an asset's metadata wholesale.
+
 ### Classic (Vertical) Format
 
 The classic CSV format used by `asset metadata get --format csv` and `asset metadata create-batch --csv-file` is designed for seamless round-trip operations:
@@ -77,7 +79,7 @@ The CSV format specifications:
 - **Header Row**: Must contain exactly `ASSET_PATH,NAME,VALUE` in that order
 - **ASSET_PATH**: Full path to the asset in Physna (e.g., `/Root/Folder/Model.stl`)
 - **NAME**: Name of the metadata field to set
-- **VALUE**: Value to assign to the metadata field. Leave empty to **delete** the field from the asset
+- **VALUE**: Value to assign to the metadata field. An empty value is skipped by default, or deletes the field from the asset when `--delete-if-empty` is passed
 - **File Encoding**: Must be UTF-8 encoded
 - **Quoting**: Values containing commas, quotes, or newlines must be enclosed in double quotes
 - **Escaping**: Double quotes within values must be escaped by doubling them (e.g., `"15.5"" diameter"`)
@@ -92,7 +94,7 @@ pcli2 asset metadata create-batch --csv-file "metadata.csv"
 
 **Deleting metadata fields via CSV:**
 
-Leave the VALUE column empty to remove a metadata field from an asset:
+Pass `--delete-if-empty` and leave the VALUE column empty to remove a metadata field from an asset:
 
 ```csv
 ASSET_PATH,NAME,VALUE
@@ -100,9 +102,13 @@ ASSET_PATH,NAME,VALUE
 /Root/Folder/Model1.stl,Material,Steel
 ```
 
-In the example above, `ObsoleteField` is deleted and `Material` is set to `Steel` in a single pass.
+```bash
+pcli2 asset metadata create-batch --csv-file "metadata.csv" --delete-if-empty
+```
 
-**Note:** The `create-batch` command groups all rows by asset path, then issues deletes (empty values) followed by updates (non-empty values) per asset in one batch. Multiple rows with the same ASSET_PATH are combined into a single API interaction.
+In the example above, `ObsoleteField` is deleted and `Material` is set to `Steel` in a single pass. Without `--delete-if-empty`, the `ObsoleteField` row would be skipped with a warning and only `Material` would be updated.
+
+**Note:** The `create-batch` command groups all rows by asset path, then issues deletes (empty values, when `--delete-if-empty` is passed) followed by updates (non-empty values) per asset in one batch. Multiple rows with the same ASSET_PATH are combined into a single API interaction.
 
 ### UI (Horizontal) Format
 
@@ -119,7 +125,7 @@ The UI format specifications:
 - **path**: Full path to the asset in Physna
 - **id**: Optional asset UUID. When present and non-empty, it takes precedence over the path and is used directly, without path resolution. An invalid UUID is an error (there is no fallback to the path, since that could silently target a different asset)
 - **metadata:&lt;field name&gt;**: One column per metadata field. The `metadata:` prefix is stripped to obtain the field name
-- **Empty metadata cells**: Skipped — the existing field value on the asset, if any, is left untouched. (This differs from the classic format, where an empty VALUE deletes the field. Spreadsheet-style exports naturally contain blank cells for fields that don't apply, so blanks are never treated as deletions in this layout)
+- **Empty metadata cells**: Skipped by default — the existing field value on the asset, if any, is left untouched. With `--delete-if-empty`, an empty cell deletes the field from the asset instead
 - **Other columns**: Any column that is not `path`, `id`, or `metadata:*` is ignored, with a warning listing the ignored columns
 - **Row identification**: Each row must provide a UUID or a path; a row with neither is an error
 
@@ -149,13 +155,16 @@ One of the most powerful features of PCLI2 is the ability to export metadata, mo
 2. **Modify Metadata Externally**:
    - Open the CSV file in a spreadsheet application (Excel, Google Sheets, etc.)
    - Make the desired changes to metadata values
-   - To **delete** a field, clear its VALUE cell (leave it blank)
+   - To **delete** a field, clear its VALUE cell (leave it blank) and reimport with `--delete-if-empty`
    - Save the file in CSV format
 
 3. **Reimport Modified Metadata**:
    ```bash
-   # Update assets with modified metadata
+   # Update assets with modified metadata (blank values are skipped)
    pcli2 asset metadata create-batch --csv-file "modified_metadata.csv"
+
+   # Or replace metadata wholesale: blank values delete the field from the asset
+   pcli2 asset metadata create-batch --csv-file "modified_metadata.csv" --delete-if-empty
    ```
 
 This workflow enables powerful bulk metadata operations while maintaining the flexibility to use familiar spreadsheet tools for data manipulation.

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -8,9 +8,9 @@ use crate::{
     actions::folders::resolve_folder_uuid_by_path,
     actions::CliActionError,
     commands::params::{
-        PARAMETER_CONTINUE_ON_ERROR, PARAMETER_FILE, PARAMETER_FILES, PARAMETER_FOLDER_PATH,
-        PARAMETER_FOLDER_UUID, PARAMETER_OVERRIDE, PARAMETER_PATH, PARAMETER_RESTORE_METADATA,
-        PARAMETER_UUID,
+        PARAMETER_CONTINUE_ON_ERROR, PARAMETER_DELETE_IF_EMPTY, PARAMETER_FILE, PARAMETER_FILES,
+        PARAMETER_FOLDER_PATH, PARAMETER_FOLDER_UUID, PARAMETER_OVERRIDE, PARAMETER_PATH,
+        PARAMETER_RESTORE_METADATA, PARAMETER_UUID,
     },
     configuration::Configuration,
     error::CliError,
@@ -355,6 +355,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
 
     let show_progress = sub_matches.get_flag("progress");
     let continue_on_error = sub_matches.get_flag(PARAMETER_CONTINUE_ON_ERROR);
+    let delete_if_empty = sub_matches.get_flag(PARAMETER_DELETE_IF_EMPTY);
     let requested_format = sub_matches
         .get_one::<String>("csv-format")
         .map(|s| BatchCsvFormat::from_arg(s))
@@ -365,7 +366,8 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
     // malformed file fails fast instead of half-applying.
     let file = std::fs::File::open(csv_file_path)
         .map_err(|e| CliError::ActionError(CliActionError::IoError(e)))?;
-    let parsed = parse_batch_csv(file, requested_format).map_err(CliError::ActionError)?;
+    let parsed =
+        parse_batch_csv(file, requested_format, delete_if_empty).map_err(CliError::ActionError)?;
 
     debug!("Parsed batch CSV as {:?} format", parsed.format);
     for warning in &parsed.warnings {
@@ -536,7 +538,8 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
             }
         };
 
-        // Split into fields to delete (empty value) and fields to update (non-empty value)
+        // Split into fields to delete (empty value, only present when the file
+        // was parsed with --delete-if-empty) and fields to update (non-empty value)
         let mut fields_to_delete: Vec<String> = Vec::new();
         let mut typed_metadata: HashMap<String, serde_json::Value> = HashMap::new();
 

--- a/src/actions/assets/metadata_batch_csv.rs
+++ b/src/actions/assets/metadata_batch_csv.rs
@@ -3,12 +3,15 @@
 //! Two input layouts are supported:
 //!
 //! - **Classic (vertical)**: `ASSET_PATH,NAME,VALUE` — one row per asset+field
-//!   combination. An empty VALUE means "delete this metadata field".
+//!   combination.
 //! - **UI (horizontal)**: one row per asset with a `path` column, an optional
 //!   `id` column (asset UUID, takes precedence over the path when present),
 //!   and one `metadata:<field name>` column per metadata field, as exported by
-//!   the Physna web UI's bulk metadata upload. Empty metadata cells are
-//!   skipped (the existing field value, if any, is left untouched).
+//!   the Physna web UI's bulk metadata upload.
+//!
+//! In both layouts an empty value is skipped by default (the existing field
+//! value, if any, is left untouched). With `--delete-if-empty` an empty value
+//! instead means "delete this metadata field from the asset".
 //!
 //! The layout is auto-detected from the header row: if any column name starts
 //! with the `metadata:` prefix the file is treated as UI format, otherwise as
@@ -68,8 +71,8 @@ impl BatchCsvFormat {
 pub struct BatchEntry {
     pub asset: BatchAssetRef,
     /// Raw string values keyed by metadata field name. An empty string means
-    /// "delete this field" (only the classic format produces empty values;
-    /// the UI parser skips empty cells).
+    /// "delete this field"; empty values are only produced when the file is
+    /// parsed with `delete_if_empty`, otherwise they are skipped.
     pub metadata: HashMap<String, String>,
 }
 
@@ -87,10 +90,14 @@ pub struct ParsedBatch {
 
 /// Parse a batch metadata CSV from `reader`, detecting the layout if
 /// `requested` is [`BatchCsvFormat::Auto`].
+///
+/// When `delete_if_empty` is true, empty values are kept in the entries as
+/// delete markers; otherwise they are skipped with a warning.
 #[allow(clippy::result_large_err)]
 pub fn parse_batch_csv<R: Read>(
     reader: R,
     requested: BatchCsvFormat,
+    delete_if_empty: bool,
 ) -> Result<ParsedBatch, CliActionError> {
     let mut csv_reader = csv::Reader::from_reader(reader);
     let headers = csv_reader.headers()?.clone();
@@ -111,8 +118,8 @@ pub fn parse_batch_csv<R: Read>(
     };
 
     match format {
-        BatchCsvFormat::Ui => parse_ui(csv_reader, &headers),
-        _ => parse_classic(csv_reader),
+        BatchCsvFormat::Ui => parse_ui(csv_reader, &headers, delete_if_empty),
+        _ => parse_classic(csv_reader, delete_if_empty),
     }
 }
 
@@ -157,8 +164,12 @@ impl EntryAccumulator {
 
 /// Parse the classic vertical ASSET_PATH,NAME,VALUE layout.
 #[allow(clippy::result_large_err)]
-fn parse_classic<R: Read>(mut csv_reader: csv::Reader<R>) -> Result<ParsedBatch, CliActionError> {
+fn parse_classic<R: Read>(
+    mut csv_reader: csv::Reader<R>,
+    delete_if_empty: bool,
+) -> Result<ParsedBatch, CliActionError> {
     let mut accumulator = EntryAccumulator::new();
+    let mut skipped_empty = 0usize;
 
     for result in csv_reader.records() {
         let record = result?;
@@ -167,7 +178,13 @@ fn parse_classic<R: Read>(mut csv_reader: csv::Reader<R>) -> Result<ParsedBatch,
             let metadata_name = record[1].trim();
             let metadata_value = record[2].trim();
 
-            // Empty values are kept - they mean "delete existing metadata"
+            // Empty values either mark the field for deletion (with
+            // --delete-if-empty) or are skipped, leaving the field untouched.
+            if metadata_value.is_empty() && !delete_if_empty {
+                skipped_empty += 1;
+                continue;
+            }
+
             let clean_asset_path = asset_path.strip_prefix('/').unwrap_or(asset_path);
             accumulator.add(
                 BatchAssetRef::Path(clean_asset_path.to_string()),
@@ -177,9 +194,17 @@ fn parse_classic<R: Read>(mut csv_reader: csv::Reader<R>) -> Result<ParsedBatch,
         }
     }
 
+    let mut warnings = Vec::new();
+    if skipped_empty > 0 {
+        warnings.push(format!(
+            "{} row(s) with an empty VALUE were skipped; pass --delete-if-empty to delete those metadata fields instead",
+            skipped_empty
+        ));
+    }
+
     Ok(ParsedBatch {
         entries: accumulator.entries,
-        warnings: Vec::new(),
+        warnings,
         format: BatchCsvFormat::Classic,
     })
 }
@@ -189,6 +214,7 @@ fn parse_classic<R: Read>(mut csv_reader: csv::Reader<R>) -> Result<ParsedBatch,
 fn parse_ui<R: Read>(
     mut csv_reader: csv::Reader<R>,
     headers: &csv::StringRecord,
+    delete_if_empty: bool,
 ) -> Result<ParsedBatch, CliActionError> {
     let mut warnings: Vec<String> = Vec::new();
     let mut path_column: Option<usize> = None;
@@ -280,9 +306,9 @@ fn parse_ui<R: Read>(
         let mut row_has_values = false;
         for (index, field_name) in &metadata_columns {
             let value = record.get(*index).map(str::trim).unwrap_or("");
-            // Empty cells mean "no value for this asset" and are skipped,
-            // unlike the classic format where an empty VALUE deletes the field.
-            if !value.is_empty() {
+            // Empty cells mark the field for deletion (with --delete-if-empty)
+            // or are skipped, leaving the existing field value untouched.
+            if !value.is_empty() || delete_if_empty {
                 accumulator.add(asset.clone(), field_name.clone(), value.to_string());
                 row_has_values = true;
             }
@@ -310,7 +336,15 @@ mod tests {
 
     #[allow(clippy::result_large_err)]
     fn parse(content: &str, format: BatchCsvFormat) -> Result<ParsedBatch, CliActionError> {
-        parse_batch_csv(content.as_bytes(), format)
+        parse_batch_csv(content.as_bytes(), format, false)
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn parse_delete_if_empty(
+        content: &str,
+        format: BatchCsvFormat,
+    ) -> Result<ParsedBatch, CliActionError> {
+        parse_batch_csv(content.as_bytes(), format, true)
     }
 
     #[test]
@@ -332,11 +366,36 @@ mod tests {
     }
 
     #[test]
-    fn classic_keeps_empty_values_for_deletion() {
+    fn classic_skips_empty_values_by_default() {
+        let csv = "ASSET_PATH,NAME,VALUE\n\
+                   folder/a.stl,Material,\n\
+                   folder/a.stl,Weight,15.5 kg\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        assert_eq!(parsed.entries.len(), 1);
+        let entry = &parsed.entries[0];
+        assert_eq!(entry.metadata.len(), 1);
+        assert_eq!(entry.metadata.get("Weight").unwrap(), "15.5 kg");
+        assert!(parsed
+            .warnings
+            .iter()
+            .any(|w| w.contains("--delete-if-empty")));
+    }
+
+    #[test]
+    fn classic_row_with_only_empty_values_produces_no_entry() {
         let csv = "ASSET_PATH,NAME,VALUE\n\
                    folder/a.stl,Material,\n";
         let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        assert!(parsed.entries.is_empty());
+    }
+
+    #[test]
+    fn classic_keeps_empty_values_with_delete_if_empty() {
+        let csv = "ASSET_PATH,NAME,VALUE\n\
+                   folder/a.stl,Material,\n";
+        let parsed = parse_delete_if_empty(csv, BatchCsvFormat::Auto).unwrap();
         assert_eq!(parsed.entries[0].metadata.get("Material").unwrap(), "");
+        assert!(parsed.warnings.is_empty());
     }
 
     #[test]
@@ -381,13 +440,35 @@ mod tests {
     }
 
     #[test]
-    fn ui_empty_cells_are_skipped_not_deleted() {
+    fn ui_empty_cells_are_skipped_by_default() {
         let csv = "path,id,metadata:Material,metadata:Color,metadata:Weight\n\
                    /domain/assembly.sldasm,,Mixed,,\n";
         let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
         let entry = &parsed.entries[0];
         assert_eq!(entry.metadata.len(), 1);
         assert_eq!(entry.metadata.get("Material").unwrap(), "Mixed");
+    }
+
+    #[test]
+    fn ui_empty_cells_are_kept_with_delete_if_empty() {
+        let csv = "path,id,metadata:Material,metadata:Color,metadata:Weight\n\
+                   /domain/assembly.sldasm,,Mixed,,\n";
+        let parsed = parse_delete_if_empty(csv, BatchCsvFormat::Auto).unwrap();
+        let entry = &parsed.entries[0];
+        assert_eq!(entry.metadata.len(), 3);
+        assert_eq!(entry.metadata.get("Material").unwrap(), "Mixed");
+        assert_eq!(entry.metadata.get("Color").unwrap(), "");
+        assert_eq!(entry.metadata.get("Weight").unwrap(), "");
+    }
+
+    #[test]
+    fn ui_row_with_all_empty_cells_is_kept_with_delete_if_empty() {
+        let csv = "path,id,metadata:Material\n\
+                   /domain/part1.sldprt,,\n";
+        let parsed = parse_delete_if_empty(csv, BatchCsvFormat::Auto).unwrap();
+        assert_eq!(parsed.entries.len(), 1);
+        assert_eq!(parsed.entries[0].metadata.get("Material").unwrap(), "");
+        assert!(parsed.warnings.is_empty());
     }
 
     #[test]

--- a/src/commands/metadata.rs
+++ b/src/commands/metadata.rs
@@ -3,9 +3,9 @@
 //! This module defines CLI commands related to asset metadata management.
 
 use crate::commands::params::{
-    continue_on_error_parameter, format_parameter, format_pretty_parameter,
-    format_with_headers_parameter, format_with_metadata_parameter, path_parameter,
-    tenant_parameter, uuid_parameter, COMMAND_CREATE, COMMAND_DELETE, COMMAND_GET,
+    continue_on_error_parameter, delete_if_empty_parameter, format_parameter,
+    format_pretty_parameter, format_with_headers_parameter, format_with_metadata_parameter,
+    path_parameter, tenant_parameter, uuid_parameter, COMMAND_CREATE, COMMAND_DELETE, COMMAND_GET,
     COMMAND_METADATA,
 };
 use clap::{Arg, ArgAction, ArgGroup, Command};
@@ -109,8 +109,7 @@ pub fn metadata_command() -> Command {
                     - NAME: The name of the metadata field to set\n\
                     - VALUE: The value to set for the metadata field\n\n\
                     If an asset has multiple metadata fields to update, include multiple rows \n\
-                    with the same ASSET_PATH but different NAME and VALUE combinations. \
-                    An empty VALUE deletes the metadata field from the asset.\n\n\
+                    with the same ASSET_PATH but different NAME and VALUE combinations.\n\n\
                     Example:\n\
                     ASSET_PATH,NAME,VALUE\n\
                     folder/subfolder/asset1.stl,Material,Steel\n\
@@ -121,8 +120,12 @@ pub fn metadata_command() -> Command {
                     - path: The full path of the asset in Physna\n\
                     - id: Optional asset UUID; when present it takes precedence over the path\n\
                     - metadata:<field name>: One column per metadata field to set\n\n\
-                    Empty metadata cells are skipped (the existing value is left untouched). \
                     Columns other than path, id, and metadata:* are ignored with a warning.\n\n\
+                    In both formats, empty values are skipped by default (the existing \
+                    metadata field, if any, is left untouched), so the file can be used to \
+                    incrementally add or update fields. Pass --delete-if-empty to instead \
+                    delete the metadata field from the asset when its value is empty, e.g. \
+                    to replace an asset's metadata wholesale.\n\n\
                     Example:\n\
                     path,id,metadata:Material,metadata:Color\n\
                     /folder/part1.sldprt,,Steel,Blue\n\
@@ -169,6 +172,7 @@ pub fn metadata_command() -> Command {
                         .required(false)
                         .help("Display progress bar during processing"),
                 )
+                .arg(delete_if_empty_parameter())
                 .arg(continue_on_error_parameter()),
         )
         .subcommand(

--- a/src/commands/params.rs
+++ b/src/commands/params.rs
@@ -112,6 +112,7 @@ pub const PARAMETER_PROGRESS: &str = "progress";
 pub const PARAMETER_LIMIT: &str = "limit";
 pub const PARAMETER_FOLDER_PATHS: &str = "folder-paths";
 pub const PARAMETER_CONTINUE_ON_ERROR: &str = "continue-on-error";
+pub const PARAMETER_DELETE_IF_EMPTY: &str = "delete-if-empty";
 pub const PARAMETER_DELAY: &str = "delay";
 pub const PARAMETER_LOCAL_PATH: &str = "local-path";
 pub const PARAMETER_SKIP_EXISTING: &str = "skip-existing";
@@ -494,6 +495,18 @@ pub fn continue_on_error_parameter() -> Arg {
         .action(ArgAction::SetTrue)
         .required(false)
         .help("Continue processing remaining items when a recoverable error occurs")
+}
+
+/// Create the delete-if-empty parameter.
+pub fn delete_if_empty_parameter() -> Arg {
+    Arg::new(PARAMETER_DELETE_IF_EMPTY)
+        .long(PARAMETER_DELETE_IF_EMPTY)
+        .action(ArgAction::SetTrue)
+        .required(false)
+        .help(
+            "Delete a metadata field from the asset when the input file contains \
+            an empty value for it (by default empty values are skipped)",
+        )
 }
 
 /// Create the delay parameter.


### PR DESCRIPTION
## Summary

- New `--delete-if-empty` flag (default: off) for `asset metadata create-batch`, giving precise control over what an empty value in the input CSV means, in both the classic and UI layouts.
- **Without the flag**, empty values are skipped: existing metadata fields are left untouched, so a sparse file incrementally adds or updates fields. Skipped classic-format rows produce a single aggregate warning pointing at the flag.
- **With the flag**, an empty value deletes that metadata field from the asset — restoring the classic format's wholesale-replace behavior and extending it to the UI format, which previously could not delete at all.
- Docs updated across CHANGELOG, README, mdBook (`docs/src/metadata-operations.md`), and the command's `--help` text.
- Version bumped to 1.8.0.

## Behavior change

Previously an empty `VALUE` in the classic layout always deleted the field. Deletion is now opt-in via `--delete-if-empty`. The feature was user-requested and the old behavior had no users relying on it yet.

## Test plan

- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean
- [x] Full test suite passes, including six new parser tests covering both formats with and without the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)