### PR TITLE
Release v1.8.1: metadata field pagination fix and docs deploy resilience

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -87,10 +87,21 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:
+      # The Pages backend occasionally stalls a deployment in "queued" until
+      # the action's 10-minute timeout (and a stalled deployment also breaks
+      # manual re-runs of this job with "Deployment cancelled"). A fresh
+      # deployment attempt supersedes the stalled one, so retry once before
+      # failing the run.
       - name: Deploy to GitHub Pages
         id: deployment
+        uses: actions/deploy-pages@v4
+        continue-on-error: true
+
+      - name: Retry deployment after transient Pages failure
+        id: deployment_retry
+        if: steps.deployment.outcome == 'failure'
         uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Metadata field listing now retrieves all pages** - `get_metadata_fields` fetched the `/tenants/{id}/metadata-fields` endpoint without pagination parameters, so only the first page (20 fields) was returned. For tenants with more metadata fields this had two consequences: the type-mismatch pre-check during metadata updates silently did not protect fields beyond the first page, and every batch update issued a doomed field-registration attempt (HTTP 409 "already exists") for each field the truncated list was missing. The client now walks all pages (200 per page). Affects `asset metadata create-batch` and any command that registers or type-checks metadata fields.
+
 ## [1.8.0] - 2026-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-07-02
+
 ### Fixed
 - **Metadata field listing now retrieves all pages** - `get_metadata_fields` fetched the `/tenants/{id}/metadata-fields` endpoint without pagination parameters, so only the first page (20 fields) was returned. For tenants with more metadata fields this had two consequences: the type-mismatch pre-check during metadata updates silently did not protect fields beyond the first page, and every batch update issued a doomed field-registration attempt (HTTP 409 "already exists") for each field the truncated list was missing. The client now walks all pages (200 per page). Affects `asset metadata create-batch` and any command that registers or type-checks metadata fields.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/src/model.rs
+++ b/src/model.rs
@@ -1793,6 +1793,9 @@ pub struct MetadataFieldListResponse {
     /// List of metadata fields
     #[serde(rename = "metadataFields")]
     pub metadata_fields: Vec<MetadataField>,
+    /// Pagination information (absent if the endpoint returns an unpaginated list)
+    #[serde(rename = "pageData")]
+    pub page_data: Option<PageData>,
 }
 
 /// Represents a dependency relationship for an asset from the API

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -2275,21 +2275,46 @@ impl PhysnaApiClient {
 
     /// Get all metadata fields for a tenant
     ///
-    /// This method retrieves the list of all metadata fields defined for the specified tenant.
+    /// This method retrieves the list of all metadata fields defined for the specified
+    /// tenant, walking every page of the paginated endpoint. Without explicit
+    /// pagination the API returns only the first page (20 fields), which previously
+    /// made fields beyond that page look unregistered.
     ///
     /// # Arguments
     /// * `tenant_id` - The ID of the tenant
     ///
     /// # Returns
-    /// * `Ok(MetadataFieldListResponse)` - List of metadata fields for the tenant
+    /// * `Ok(MetadataFieldListResponse)` - All metadata fields for the tenant
     /// * `Err(ApiError)` - HTTP error or JSON parsing error
     pub async fn get_metadata_fields(
         &mut self,
         tenant_id: &str,
     ) -> Result<crate::model::MetadataFieldListResponse, ApiError> {
-        let url = format!("{}/tenants/{}/metadata-fields", self.base_url, tenant_id);
+        let mut page: usize = 1;
+        let per_page: usize = 200;
+        let mut metadata_fields: Vec<crate::model::MetadataField> = Vec::new();
 
-        self.get(&url).await
+        loop {
+            let url = format!(
+                "{}/tenants/{}/metadata-fields?page={}&perPage={}",
+                self.base_url, tenant_id, page, per_page
+            );
+            let response: crate::model::MetadataFieldListResponse = self.get(&url).await?;
+            metadata_fields.extend(response.metadata_fields);
+
+            match response.page_data {
+                Some(page_data) if page_data.current_page < page_data.last_page => {
+                    page = page_data.current_page + 1;
+                }
+                // No pagination info means the endpoint returned everything at once.
+                _ => break,
+            }
+        }
+
+        Ok(crate::model::MetadataFieldListResponse {
+            metadata_fields,
+            page_data: None,
+        })
     }
 
     /// Create a new asset by uploading a file

--- a/tests/metadata_fields_pagination_test.rs
+++ b/tests/metadata_fields_pagination_test.rs
@@ -1,0 +1,89 @@
+//! Tests for metadata field listing pagination.
+//!
+//! The /tenants/{id}/metadata-fields endpoint is paginated (defaulting to 20
+//! items per page). `get_metadata_fields` must walk every page; returning only
+//! the first page previously made registered fields look unregistered, which
+//! skipped type-mismatch checks and caused a doomed re-registration attempt
+//! (HTTP 409) for every field beyond page one.
+
+use mockito::Matcher;
+use pcli2::physna_v3::PhysnaApiClient;
+
+fn page_body(names: &[&str], current_page: usize, last_page: usize) -> String {
+    let fields: Vec<String> = names
+        .iter()
+        .map(|n| format!(r#"{{"name":"{}","type":"text"}}"#, n))
+        .collect();
+    format!(
+        r#"{{"metadataFields":[{}],"pageData":{{"total":3,"perPage":200,"currentPage":{},"lastPage":{},"startIndex":0,"endIndex":0}}}}"#,
+        fields.join(","),
+        current_page,
+        last_page
+    )
+}
+
+#[tokio::test]
+async fn get_metadata_fields_walks_all_pages() {
+    let mut server = mockito::Server::new_async().await;
+
+    let page1 = server
+        .mock("GET", "/tenants/t1/metadata-fields")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "1".into()),
+            Matcher::UrlEncoded("perPage".into(), "200".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(page_body(&["Material", "Weight"], 1, 2))
+        .create_async()
+        .await;
+
+    let page2 = server
+        .mock("GET", "/tenants/t1/metadata-fields")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "2".into()),
+            Matcher::UrlEncoded("perPage".into(), "200".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(page_body(&["Family Table Info"], 2, 2))
+        .create_async()
+        .await;
+
+    let mut client = PhysnaApiClient::new().with_base_url(server.url());
+    let response = client.get_metadata_fields("t1").await.unwrap();
+
+    page1.assert_async().await;
+    page2.assert_async().await;
+
+    let names: Vec<&str> = response
+        .metadata_fields
+        .iter()
+        .map(|f| f.name.as_str())
+        .collect();
+    assert_eq!(names, vec!["Material", "Weight", "Family Table Info"]);
+}
+
+#[tokio::test]
+async fn get_metadata_fields_handles_unpaginated_response() {
+    let mut server = mockito::Server::new_async().await;
+
+    // No pageData in the response: the endpoint returned everything at once,
+    // so the client must not loop.
+    let mock = server
+        .mock("GET", "/tenants/t1/metadata-fields")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"metadataFields":[{"name":"Material","type":"text"}]}"#)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let mut client = PhysnaApiClient::new().with_base_url(server.url());
+    let response = client.get_metadata_fields("t1").await.unwrap();
+
+    mock.assert_async().await;
+    assert_eq!(response.metadata_fields.len(), 1);
+    assert_eq!(response.metadata_fields[0].name, "Material");
+}


### PR DESCRIPTION
## Summary

- **Fix: metadata field listing now retrieves all pages.** `get_metadata_fields` fetched `/tenants/{id}/metadata-fields` without pagination parameters, so the API returned only the first page (20 fields — confirmed against the OpenAPI spec: `perPage` defaults to 20, max 1000). On tenants with more fields, the type-mismatch pre-check silently skipped fields beyond the first page, and every batch update issued a doomed field-registration attempt (HTTP 409 "already exists") per missing field. The client now walks all pages (200 per page). Verified against a live tenant: 1158 fields retrieved where previously 20, no more 409s.
- **CI: retry Pages deployment once on transient failure.** The v1.8.0 docs deploy failed when the Pages backend left the deployment stuck in "queued" until the action's 10-minute timeout, and the stalled deployment also broke manual re-runs. The deploy job now retries once within the same run.
- Adds the repo's first HTTP-mock integration tests (mockito) covering multi-page walking and the unpaginated fallback.
- Version bumped to 1.8.1.

## Test plan

- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean
- [x] Full test suite passes (216 tests) including 2 new pagination tests
- [x] Live tenant verification of the pagination fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)