### PR TITLE
Release v1.8.2: deep code review bug fixes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -85,6 +85,11 @@ jobs:
           path: ./public
 
   deploy:
+    # The github-pages environment only allows deployments from main, so a
+    # manual dispatch from any other branch is doomed to fail at the
+    # environment gate. Skip the deploy in that case — the build job still
+    # validates that the documentation builds.
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.2] - 2026-07-02
+
 ### Fixed
 - **Nonexistent folder paths no longer silently resolve to the root folder** - A mistyped `--path`/`--folder-path` (e.g. `asset delete --path "/Typo/part.stl"`) previously fell through to the ROOT folder and, because assets are matched by name within the resolved folder, could target a same-named asset at the root. A non-root path that doesn't resolve is now a "Folder not found" error. An absent or `/` folder path still means the root, as before.
 - **Folder cache is invalidated on folder create/delete/rename/move** - Mutating folder operations previously left the cached folder hierarchy stale for up to an hour, so path resolutions could target deleted/renamed folders (deleting the same folder twice even reported the misleading "Folder is not empty" error).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Nonexistent folder paths no longer silently resolve to the root folder** - A mistyped `--path`/`--folder-path` (e.g. `asset delete --path "/Typo/part.stl"`) previously fell through to the ROOT folder and, because assets are matched by name within the resolved folder, could target a same-named asset at the root. A non-root path that doesn't resolve is now a "Folder not found" error. An absent or `/` folder path still means the root, as before.
+- **Folder cache is invalidated on folder create/delete/rename/move** - Mutating folder operations previously left the cached folder hierarchy stale for up to an hour, so path resolutions could target deleted/renamed folders (deleting the same folder twice even reported the misleading "Folder is not empty" error).
+- **Metadata values are no longer rewritten on upload** - `asset metadata create` and `create-batch` silently substituted characters in text values (`Ø`→`O`, `°`→`" deg"`, `″`→`"`, `…`→`...`), corrupting engineering metadata. Values now round-trip verbatim.
+- **Pagination fixes across the API client**:
+  - Three endpoints sent the pagination page size as `per_page` instead of `perPage`, so the API served its default 20 items per page: asset dependencies (×2) and `assets/state` listing. Dependency traversal now makes ~5× fewer API calls, and the state listing's safety cap is effectively 200,000 assets instead of 20,000.
+  - `asset match text` fetched only the first 50 results and presented them as complete. It now paginates through all matches and accepts `--limit` (default 100), consistent with `visual-match`.
+  - `part-search` was silently capped at 5,000 matches (50 pages); the cap is now 1,000 pages, aligned with visual search, and hitting any pagination safety cap prints a visible truncation warning instead of a debug log.
+  - `folder download`/`folder thumbnail` read only the first 1,000 direct subfolders of each folder; folders beyond that (and their entire subtrees) were silently skipped. All subfolder pages are now walked.
+  - `user list` returned an empty list if the API responded without pagination data; accumulated users are now returned.
+  - `geometric-search` gained the same stall guard as its siblings (protects against infinite pagination loops), and mid-pagination responses without page data no longer discard previously accumulated matches.
+- **Auth and error handling**:
+  - A 404 that persists after the automatic token refresh is now classified as a not-found error instead of "Conflict", and dependency queries no longer swallow unrelated auth errors into an empty dependency list.
+  - `asset metadata create-batch` now detects authentication failures that persist through token refresh (previously each remaining CSV row triggered a redundant refresh+retry cycle instead of aborting).
+  - The authentication retry of a file upload now sends the identical multipart form as the first attempt (it previously disabled `createMissingFolders`, so an upload interrupted by token expiry could fail where a fresh attempt would succeed).
+  - Concurrent batch-upload clients now inherit the configured auth URL and environment; mid-batch token refreshes previously hit the production auth endpoint and saved tokens under the wrong environment.
+  - Keyring read errors (e.g. locked keychain) are now logged instead of being silently treated as "not logged in".
+- **`--exclusive` match filtering respects folder boundaries** - A `/proj` filter previously also matched sibling folders like `/proj-archive` (bare string-prefix comparison).
+- **`folder download --resume` now skips already-downloaded assemblies** - Assemblies download as a ZIP that is extracted and deleted, so the resume check (which looked for the ZIP) re-downloaded every assembly on every resume. The extracted assembly file is now used as the marker.
+- **`asset download-folder` no longer packages stale files** - The reusable temp directory is cleared at the start of each run, so leftovers from a previously failed run can't leak into the output ZIP.
+- **Download/upload statistics are accurate** - Skipped files were counted as successes; the "Skipped (already existed)" count was always 0 for downloads and counted subdirectories for uploads.
+- **Failed confirmations and failed cache clears exit non-zero** - `asset delete`/`folder delete` exited 0 without deleting when the confirmation prompt failed (e.g. non-TTY without `--yes`); `cache clear` printed "cleared successfully" even when every purge failed. Both now report errors. `cache clear` also clears the tenant cache for all environments and the actual metadata cache file.
+- **Environment variable handling** - `PCLI2_FORMAT` set to a format not supported by a given command (e.g. `tree`) no longer aborts that command; an explicit `--format` always wins and unsupported env values fall back to the default. `PCLI2_HEADERS` now accepts `1`/`0`/`yes`/`no` in addition to `true`/`false`.
+- **Crash fixes** - A batch CSV header containing a multi-byte UTF-8 character at the `metadata:` prefix boundary panicked the parser; `asset thumbnail --file thumb.png` (bare filename) was wrongly rejected with "Parent directory does not exist"; unfollowed HTTP 3xx responses could panic the HTTP layer.
+- **`asset metadata inference` reporting** - The output now distinguishes `fields_requested` from `fields_copied` (previously all requested fields were reported as copied), and the reference asset no longer matches itself into the updated-assets count.
+
 ## [1.8.1] - 2026-07-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.8.1"
+version = "1.8.2"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -475,11 +475,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                         asset
                     }
                     Err(e) => {
-                        let error_str = format!("{}", e);
-                        if error_str.contains("Authentication")
-                            || error_str.contains("unauthorized")
-                            || error_str.contains("forbidden")
-                        {
+                        if e.is_authentication_failure() {
                             auth_failure_occurred = true;
                             report(
                                 format!("Authentication failed while looking up asset '{}': {}", asset_display, e),
@@ -559,11 +555,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                 .delete_asset_metadata(&tenant.uuid.to_string(), &asset.uuid().to_string(), keys)
                 .await
             {
-                let error_str = format!("{}", e);
-                if error_str.contains("Authentication")
-                    || error_str.contains("unauthorized")
-                    || error_str.contains("forbidden")
-                {
+                if e.is_authentication_failure() {
                     auth_failure_occurred = true;
                     report(
                         format!(
@@ -611,12 +603,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                 )
                 .await
             {
-                let error_str = format!("{}", e);
-
-                if error_str.contains("Authentication")
-                    || error_str.contains("unauthorized")
-                    || error_str.contains("forbidden")
-                {
+                if e.is_authentication_failure() {
                     auth_failure_occurred = true;
                     report(
                         format!(
@@ -633,6 +620,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                     break;
                 }
 
+                let error_str = format!("{}", e);
                 if error_str.contains("must be a") || error_str.contains("Metadata type mismatch") {
                     report(
                         format!("Type conflict for asset '{}': {}", asset_display, e),

--- a/src/actions/assets/delete.rs
+++ b/src/actions/assets/delete.rs
@@ -65,12 +65,15 @@ pub async fn delete_asset(sub_matches: &ArgMatches) -> Result<(), CliError> {
                 return Ok(());
             }
             Err(e) => {
-                // Error in prompting (e.g., not a TTY), treat as cancellation
-                eprintln!(
-                    "Error prompting for confirmation: {}. Use --yes to skip confirmation.",
-                    e
-                );
-                return Ok(());
+                // The prompt itself failed (e.g. not a TTY). Nothing was
+                // deleted, so exit with an error instead of a success code
+                // that scripts would misread as "deleted".
+                return Err(CliError::ActionError(
+                    crate::actions::CliActionError::BusinessLogicError(format!(
+                        "Confirmation prompt failed ({}). Nothing was deleted. Use --yes to skip confirmation in non-interactive environments.",
+                        e
+                    )),
+                ));
             }
         }
     }

--- a/src/actions/assets/download.rs
+++ b/src/actions/assets/download.rs
@@ -151,9 +151,11 @@ pub async fn download_asset_thumbnail(sub_matches: &ArgMatches) -> Result<(), Cl
             ));
         }
 
-        // Check if the parent directory exists
+        // Check if the parent directory exists. A bare filename like
+        // "thumb.png" has `parent() == Some("")`, which means the current
+        // directory and is always valid.
         if let Some(parent) = output_path.parent() {
-            if !parent.exists() {
+            if !parent.as_os_str().is_empty() && !parent.exists() {
                 return Err(CliError::MissingRequiredArgument(format!(
                     "Parent directory does not exist: {}",
                     parent.display()
@@ -292,8 +294,15 @@ pub async fn download_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
     // Check if progress should be displayed
     let show_progress = sub_matches.get_flag(crate::commands::params::PARAMETER_PROGRESS);
 
-    // Create a temporary directory to store downloaded files
+    // Create a temporary directory to store downloaded files. Remove any
+    // leftovers from a previous (failed) run first: the ZIP-building step
+    // below archives every file in this directory, so stale files from an
+    // earlier run would silently end up inside the output archive.
     let temp_dir = std::env::temp_dir().join(format!("pcli2_temp_{}", folder_uuid));
+    if temp_dir.exists() {
+        std::fs::remove_dir_all(&temp_dir)
+            .map_err(|e| CliError::ActionError(CliActionError::IoError(e)))?;
+    }
     std::fs::create_dir_all(&temp_dir)
         .map_err(|e| CliError::ActionError(CliActionError::IoError(e)))?;
 

--- a/src/actions/assets/match_ops.rs
+++ b/src/actions/assets/match_ops.rs
@@ -868,7 +868,10 @@ pub async fn geometric_match_folder(sub_matches: &ArgMatches) -> Result<(), CliE
                                     crate::model::normalize_path(folder_path);
                                 let normalized_candidate_path =
                                     crate::model::normalize_path(&match_result.asset.path);
-                                normalized_candidate_path.starts_with(&normalized_folder_path)
+                                crate::model::path_is_within_folder(
+                                    &normalized_candidate_path,
+                                    &normalized_folder_path,
+                                )
                             });
 
                         let reference_in_specified_folders =
@@ -877,7 +880,10 @@ pub async fn geometric_match_folder(sub_matches: &ArgMatches) -> Result<(), CliE
                                     crate::model::normalize_path(folder_path);
                                 let normalized_reference_path =
                                     crate::model::normalize_path(asset_clone.path());
-                                normalized_reference_path.starts_with(&normalized_folder_path)
+                                crate::model::path_is_within_folder(
+                                    &normalized_reference_path,
+                                    &normalized_folder_path,
+                                )
                             });
 
                         if exclusive
@@ -1368,7 +1374,10 @@ pub async fn part_match_folder(sub_matches: &ArgMatches) -> Result<(), CliError>
                                     crate::model::normalize_path(folder_path);
                                 let normalized_candidate_path =
                                     crate::model::normalize_path(&match_result.asset.path);
-                                normalized_candidate_path.starts_with(&normalized_folder_path)
+                                crate::model::path_is_within_folder(
+                                    &normalized_candidate_path,
+                                    &normalized_folder_path,
+                                )
                             });
 
                         let reference_in_specified_folders =
@@ -1377,7 +1386,10 @@ pub async fn part_match_folder(sub_matches: &ArgMatches) -> Result<(), CliError>
                                     crate::model::normalize_path(folder_path);
                                 let normalized_reference_path =
                                     crate::model::normalize_path(asset_clone.path());
-                                normalized_reference_path.starts_with(&normalized_folder_path)
+                                crate::model::path_is_within_folder(
+                                    &normalized_reference_path,
+                                    &normalized_folder_path,
+                                )
                             });
 
                         if exclusive
@@ -1898,7 +1910,10 @@ pub async fn visual_match_folder(sub_matches: &ArgMatches) -> Result<(), CliErro
                                     crate::model::normalize_path(folder_path);
                                 let normalized_candidate_path =
                                     crate::model::normalize_path(&match_result.asset.path);
-                                normalized_candidate_path.starts_with(&normalized_folder_path)
+                                crate::model::path_is_within_folder(
+                                    &normalized_candidate_path,
+                                    &normalized_folder_path,
+                                )
                             });
 
                         let reference_in_specified_folders =
@@ -1907,7 +1922,10 @@ pub async fn visual_match_folder(sub_matches: &ArgMatches) -> Result<(), CliErro
                                     crate::model::normalize_path(folder_path);
                                 let normalized_reference_path =
                                     crate::model::normalize_path(asset_clone.path());
-                                normalized_reference_path.starts_with(&normalized_folder_path)
+                                crate::model::path_is_within_folder(
+                                    &normalized_reference_path,
+                                    &normalized_folder_path,
+                                )
                             });
 
                         if exclusive
@@ -2237,12 +2255,22 @@ pub async fn text_match(sub_matches: &ArgMatches) -> Result<(), CliError> {
     let format_params = crate::format_utils::FormatParams::from_args(sub_matches);
     let format = format_params.format;
 
+    // Maximum number of results to return; the search paginates until the
+    // limit is reached or all matches are collected.
+    let limit = sub_matches
+        .get_one::<usize>(crate::commands::params::PARAMETER_LIMIT)
+        .copied()
+        .unwrap_or(100);
+
     // Extract tenant info before calling text search
     let tenant_uuid = *ctx.tenant_uuid();
     let tenant_name = ctx.tenant().name.clone();
 
     // Perform text search
-    let mut search_results = ctx.api().text_search(&tenant_uuid, &search_query).await?;
+    let mut search_results = ctx
+        .api()
+        .text_search(&tenant_uuid, &search_query, limit)
+        .await?;
 
     // Load configuration to get the UI base URL
     let configuration =

--- a/src/actions/assets/metadata.rs
+++ b/src/actions/assets/metadata.rs
@@ -122,6 +122,12 @@ pub async fn metadata_inference(sub_matches: &ArgMatches) -> Result<(), CliError
     };
 
     for match_result in search_results.matches {
+        // The reference asset matches itself at 100%; copying its own
+        // metadata onto itself is a no-op that inflates the updated count.
+        if match_result.asset.uuid == reference_asset.uuid() {
+            continue;
+        }
+
         // If exclusive flag is set, only process assets in the same parent folder
         if exclusive {
             let candidate_parent_folder_path = {
@@ -166,12 +172,15 @@ pub async fn metadata_inference(sub_matches: &ArgMatches) -> Result<(), CliError
         }
     }
 
-    // Create a response structure to output the results
+    // Create a response structure to output the results. `fields_copied`
+    // reports the fields that were actually copied (present on the reference
+    // asset), not everything that was requested.
     let response = serde_json::json!({
         "reference_asset_path": asset_path,
         "reference_asset_uuid": reference_asset.uuid(),
         "threshold": threshold,
-        "fields_copied": metadata_names,
+        "fields_requested": metadata_names,
+        "fields_copied": available_fields,
         "assets_updated": assets_updated.len(),
         "updated_assets": assets_updated
     });

--- a/src/actions/assets/metadata_batch_csv.rs
+++ b/src/actions/assets/metadata_batch_csv.rs
@@ -127,12 +127,14 @@ pub fn parse_batch_csv<R: Read>(
 /// (trimmed, prefix stripped) when the header is a metadata column.
 fn is_metadata_column(header: &str) -> Option<&str> {
     let prefix_len = METADATA_COLUMN_PREFIX.len();
-    if header.len() >= prefix_len
-        && header[..prefix_len].eq_ignore_ascii_case(METADATA_COLUMN_PREFIX)
-    {
-        Some(header[prefix_len..].trim())
-    } else {
-        None
+    // `get` (rather than direct slicing) avoids a panic when the byte at
+    // `prefix_len` falls inside a multi-byte UTF-8 character; such a header
+    // cannot start with the all-ASCII prefix anyway.
+    match (header.get(..prefix_len), header.get(prefix_len..)) {
+        (Some(prefix), Some(rest)) if prefix.eq_ignore_ascii_case(METADATA_COLUMN_PREFIX) => {
+            Some(rest.trim())
+        }
+        _ => None,
     }
 }
 
@@ -528,6 +530,17 @@ mod tests {
         let entry = &parsed.entries[0];
         assert_eq!(entry.metadata.get("Material").unwrap(), "Steel");
         assert_eq!(entry.metadata.get("Color").unwrap(), "Blue");
+    }
+
+    #[test]
+    fn multibyte_utf8_header_does_not_panic() {
+        // Regression: byte-slicing the header at the prefix length panicked
+        // when the boundary fell inside a multi-byte UTF-8 character.
+        let csv = "ASSET_PATH,NAME,metadataé\n\
+                   folder/a.stl,Material,Steel\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        // "metadataé" is not a metadata: column, so this is classic format.
+        assert_eq!(parsed.format, BatchCsvFormat::Classic);
     }
 
     #[test]

--- a/src/actions/cache.rs
+++ b/src/actions/cache.rs
@@ -66,30 +66,53 @@ pub async fn clear_cache(sub_matches: &ArgMatches) -> Result<(), CliError> {
         }
     }
 
+    // Track failures so the command exits non-zero when a purge fails,
+    // instead of printing a success message that scripts would trust.
+    let mut failures: Vec<String> = Vec::new();
+
     // Clear folder cache
     if clear_all || clear_folder {
         match crate::folder_cache::FolderCache::purge_all() {
             Ok(()) => eprintln!("✓ Folder cache cleared"),
-            Err(e) => eprintln!("✗ Failed to clear folder cache: {}", e),
+            Err(e) => {
+                eprintln!("✗ Failed to clear folder cache: {}", e);
+                failures.push(format!("folder cache: {}", e));
+            }
         }
     }
 
     // Clear metadata cache
     if clear_all || clear_metadata {
-        // Metadata cache files are stored in the cache directory under metadata_cache/
-        // We need to delete all .json files in that directory
+        // The metadata cache lives in two historical locations: the
+        // metadata_cache/ directory and the metadata_cache.json file that
+        // MetadataCache actually writes. Purge both.
         let base_cache_dir = crate::cache::BaseCache::get_cache_dir();
+        let mut metadata_ok = true;
+
         let metadata_cache_dir = base_cache_dir.join("metadata_cache");
         if metadata_cache_dir.exists() {
-            match std::fs::remove_dir_all(&metadata_cache_dir) {
-                Ok(()) => eprintln!("✓ Metadata cache cleared"),
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    eprintln!("✓ Metadata cache cleared (was empty)")
+            if let Err(e) = std::fs::remove_dir_all(&metadata_cache_dir) {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    eprintln!("✗ Failed to clear metadata cache directory: {}", e);
+                    failures.push(format!("metadata cache: {}", e));
+                    metadata_ok = false;
                 }
-                Err(e) => eprintln!("✗ Failed to clear metadata cache: {}", e),
             }
-        } else {
-            eprintln!("✓ Metadata cache cleared (was empty)");
+        }
+
+        let metadata_cache_file = base_cache_dir.join("metadata_cache.json");
+        if metadata_cache_file.exists() {
+            if let Err(e) = std::fs::remove_file(&metadata_cache_file) {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    eprintln!("✗ Failed to clear metadata cache file: {}", e);
+                    failures.push(format!("metadata cache file: {}", e));
+                    metadata_ok = false;
+                }
+            }
+        }
+
+        if metadata_ok {
+            eprintln!("✓ Metadata cache cleared");
         }
     }
 
@@ -97,12 +120,25 @@ pub async fn clear_cache(sub_matches: &ArgMatches) -> Result<(), CliError> {
     if clear_all || clear_tenant {
         match crate::tenant_cache::TenantCache::invalidate_all() {
             Ok(()) => eprintln!("✓ Tenant cache cleared"),
-            Err(e) => eprintln!("✗ Failed to clear tenant cache: {}", e),
+            Err(e) => {
+                eprintln!("✗ Failed to clear tenant cache: {}", e);
+                failures.push(format!("tenant cache: {}", e));
+            }
         }
     }
 
     eprintln!();
-    eprintln!("Cache cleared successfully. Fresh data will be fetched from the API on next use.");
-
-    Ok(())
+    if failures.is_empty() {
+        eprintln!(
+            "Cache cleared successfully. Fresh data will be fetched from the API on next use."
+        );
+        Ok(())
+    } else {
+        Err(CliError::ActionError(
+            crate::actions::CliActionError::BusinessLogicError(format!(
+                "Cache clear failed for: {}",
+                failures.join("; ")
+            )),
+        ))
+    }
 }

--- a/src/actions/folders.rs
+++ b/src/actions/folders.rs
@@ -208,6 +208,12 @@ pub async fn rename_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
         ));
     }
 
+    // The cached folder hierarchy still holds the old name; drop it so the
+    // next path resolution rebuilds from the API.
+    crate::folder_cache::FolderCache::invalidate(&tenant_uuid.to_string()).unwrap_or_else(|e| {
+        tracing::debug!("Failed to invalidate folder cache: {}", e);
+    });
+
     Ok(())
 }
 
@@ -271,6 +277,12 @@ pub async fn move_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
     )
     .await?;
 
+    // The cached folder hierarchy still shows the old location; drop it so
+    // the next path resolution rebuilds from the API.
+    crate::folder_cache::FolderCache::invalidate(&tenant.uuid.to_string()).unwrap_or_else(|e| {
+        tracing::debug!("Failed to invalidate folder cache: {}", e);
+    });
+
     Ok(())
 }
 
@@ -313,6 +325,12 @@ pub async fn create_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
 
     api.create_folder(&tenant.uuid, name.as_str(), parent_folder_uuid)
         .await?;
+
+    // Drop the cached folder hierarchy so the new folder resolves without
+    // relying on the cache-miss refresh heuristic.
+    crate::folder_cache::FolderCache::invalidate(&tenant.uuid.to_string()).unwrap_or_else(|e| {
+        tracing::debug!("Failed to invalidate folder cache: {}", e);
+    });
 
     Ok(())
 }
@@ -379,12 +397,15 @@ pub async fn delete_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
                 return Ok(());
             }
             Err(e) => {
-                // Error in prompting (e.g., not a TTY), treat as cancellation
-                eprintln!(
-                    "Error prompting for confirmation: {}. Use --yes to skip confirmation.",
-                    e
-                );
-                return Ok(());
+                // The prompt itself failed (e.g. not a TTY). Nothing was
+                // deleted, so exit with an error instead of a success code
+                // that scripts would misread as "deleted".
+                return Err(CliError::ActionError(
+                    crate::actions::CliActionError::BusinessLogicError(format!(
+                        "Confirmation prompt failed ({}). Nothing was deleted. Use --yes to skip confirmation in non-interactive environments.",
+                        e
+                    )),
+                ));
             }
         }
     }
@@ -393,7 +414,16 @@ pub async fn delete_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
         .delete_folder(&tenant.uuid, &folder_uuid, force_flag)
         .await
     {
-        Ok(()) => Ok(()),
+        Ok(()) => {
+            // The cached folder hierarchy still contains the deleted folder;
+            // drop it so subsequent path resolutions don't target it.
+            crate::folder_cache::FolderCache::invalidate(&tenant.uuid.to_string()).unwrap_or_else(
+                |e| {
+                    tracing::debug!("Failed to invalidate folder cache: {}", e);
+                },
+            );
+            Ok(())
+        }
         Err(api_error) => {
             // Check if this is a 404 error on a folder deletion, which likely means the folder is not empty
             if api_error.to_string().contains("404 Not Found") && !force_flag {
@@ -625,16 +655,11 @@ pub async fn download_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
             all_assets_with_paths.push((asset.clone(), relative_path, physna_path));
         }
 
-        // Get subfolders of current folder to process next
-        // Use get_folder_contents to get only direct children of the current folder
+        // Get subfolders of current folder to process next. Walks every page
+        // so folders with more direct subfolders than one page still have
+        // their full subtree processed.
         let subfolders_response = api
-            .get_folder_contents(
-                &tenant.uuid,
-                Some(&current_folder_uuid),
-                "folders",
-                Some(1),
-                Some(1000),
-            )
+            .list_all_subfolders(&tenant.uuid, Some(&current_folder_uuid))
             .await?;
         for folder in subfolders_response.folders() {
             // Get the full folder details to get the name
@@ -729,6 +754,7 @@ pub async fn download_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
         let asset_id = asset.uuid().to_string();
         let asset_name = asset.name().to_string();
         let asset_file_path = dest_dir.join(&relative_path);
+        let is_assembly = asset.is_assembly();
         let semaphore = semaphore.clone();
         let progress_bar_clone = progress_bar.clone();
         let multi_progress_clone = multi_progress.clone();
@@ -759,16 +785,24 @@ pub async fn download_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
                 None
             };
 
-            // Check if resume flag is set and file already exists
-            if resume_flag && asset_file_path.exists() {
-                tracing::debug!("Skipping existing file: {}", asset_file_path.display());
+            // Check if resume flag is set and the asset already exists on disk.
+            // Assemblies download as a ZIP that is extracted and then deleted,
+            // so the on-disk marker for an assembly is the extracted assembly
+            // file (its original name), not the transient .zip path.
+            let resume_marker = if is_assembly {
+                asset_file_path.with_file_name(&asset_name)
+            } else {
+                asset_file_path.clone()
+            };
+            if resume_flag && resume_marker.exists() {
+                tracing::debug!("Skipping existing file: {}", resume_marker.display());
 
                 // Update overall progress bar if present
                 if let Some(ref pb) = progress_bar_clone {
                     pb.inc(1);
                 }
 
-                return Ok(Ok(asset_name));
+                return Ok(Ok((asset_name, true)));
             }
 
             // Add delay if specified (only when actually downloading, not when skipping)
@@ -894,7 +928,7 @@ pub async fn download_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
                         pb.inc(1);
                     }
 
-                    Ok(Ok(asset_name))
+                    Ok(Ok((asset_name, false)))
                 }
                 Err(e) => {
                     // Update individual progress bar for error
@@ -915,14 +949,21 @@ pub async fn download_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
         tasks.push(task);
     }
 
+    // Track how many assets were skipped because they already existed
+    let mut skipped_count = 0;
+
     // Wait for all tasks to complete - always process all tasks to get accurate counts
     for task in tasks {
         match task.await {
             Ok(task_result) => {
                 match task_result {
                     Ok(asset_result) => match asset_result {
-                        Ok(_asset_name) => {
-                            success_count += 1;
+                        Ok((_asset_name, was_skipped)) => {
+                            if was_skipped {
+                                skipped_count += 1;
+                            } else {
+                                success_count += 1;
+                            }
                         }
                         Err((asset_name, physna_path, error, _is_recoverable)) => {
                             error_count += 1;
@@ -977,9 +1018,9 @@ pub async fn download_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
     // Report summary with nice statistics - print this FIRST so errors appear above it
     print_download_summary(
         success_count,
+        skipped_count,
         error_count,
         total_assets,
-        resume_flag,
         &dest_dir,
     );
 
@@ -1010,22 +1051,15 @@ pub async fn download_folder(sub_matches: &ArgMatches) -> Result<(), CliError> {
 /// Print download statistics summary
 fn print_download_summary(
     success_count: usize,
+    skipped_count: usize,
     error_count: usize,
     total_assets: usize,
-    resume_flag: bool,
     dest_dir: &std::path::PathBuf,
 ) {
     println!("\n📊 Download Statistics Report");
     println!("===========================");
     println!("✅ Successfully downloaded: {}", success_count);
-    if resume_flag {
-        // For resume, we need to calculate how many were skipped
-        // This requires knowing the total number of assets vs. how many were actually downloaded
-        let skipped_count = total_assets - success_count - error_count;
-        println!("⏭️  Skipped (already existed): {}", skipped_count);
-    } else {
-        println!("⏭️  Skipped (already existed): 0");
-    }
+    println!("⏭️  Skipped (already existed): {}", skipped_count);
     if error_count > 0 {
         println!("❌ Failed downloads: {}", error_count);
     } else {
@@ -1186,16 +1220,11 @@ pub async fn download_folder_thumbnails(sub_matches: &clap::ArgMatches) -> Resul
             all_assets_with_paths.push((asset.clone(), relative_path, physna_path));
         }
 
-        // Get subfolders of current folder to process next
-        // Use get_folder_contents to get only direct children of the current folder
+        // Get subfolders of current folder to process next. Walks every page
+        // so folders with more direct subfolders than one page still have
+        // their full subtree processed.
         let subfolders_response = api
-            .get_folder_contents(
-                &tenant.uuid,
-                Some(&current_folder_uuid),
-                "folders",
-                Some(1),
-                Some(1000),
-            )
+            .list_all_subfolders(&tenant.uuid, Some(&current_folder_uuid))
             .await?;
         for folder in subfolders_response.folders() {
             // Get the full folder details to get the name
@@ -1809,6 +1838,13 @@ pub async fn upload_folder(sub_matches: &clap::ArgMatches) -> Result<(), crate::
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| CliError::ActionError(crate::actions::CliActionError::IoError(e)))?;
 
+    // Only files are uploaded; excluding directories up front keeps the
+    // total (and therefore the skipped/failed accounting) accurate.
+    let entries: Vec<_> = entries
+        .into_iter()
+        .filter(|entry| !entry.path().is_dir())
+        .collect();
+
     // Store the total count before moving entries
     let total_entries_count = entries.len();
 
@@ -1931,7 +1967,7 @@ pub async fn upload_folder(sub_matches: &clap::ArgMatches) -> Result<(), crate::
                     if let Some(ref pb) = progress_bar_clone {
                         pb.inc(1);
                     }
-                    return Ok(Ok(file_name_str));
+                    return Ok(Ok((file_name_str, true)));
                 } else {
                     return Err(CliError::ActionError(crate::actions::CliActionError::BusinessLogicError(
                         format!("Asset already exists: {}. Use --skip-existing to skip existing assets.", file_name_str)
@@ -1992,7 +2028,7 @@ pub async fn upload_folder(sub_matches: &clap::ArgMatches) -> Result<(), crate::
                         pb.inc(1);
                     }
 
-                    Ok(Ok(file_name_str))
+                    Ok(Ok((file_name_str, false)))
                 }
                 Err(e) => {
                     // Update individual progress bar for error
@@ -2025,6 +2061,7 @@ pub async fn upload_folder(sub_matches: &clap::ArgMatches) -> Result<(), crate::
     // Wait for all tasks to complete
     let mut success_count = 0;
     let mut error_count = 0;
+    let mut skipped_count = 0;
 
     for task in tasks {
         match task.await {
@@ -2032,12 +2069,16 @@ pub async fn upload_folder(sub_matches: &clap::ArgMatches) -> Result<(), crate::
                 match task_result {
                     Ok(asset_result) => {
                         match asset_result {
-                            Ok(asset_name) => {
-                                success_count += 1;
-                                // Only print individual success messages if progress is not shown
-                                // Otherwise, the progress bar already shows the status
-                                if !show_progress {
-                                    println!("Successfully uploaded: {}", asset_name);
+                            Ok((asset_name, was_skipped)) => {
+                                if was_skipped {
+                                    skipped_count += 1;
+                                } else {
+                                    success_count += 1;
+                                    // Only print individual success messages if progress is not shown
+                                    // Otherwise, the progress bar already shows the status
+                                    if !show_progress {
+                                        println!("Successfully uploaded: {}", asset_name);
+                                    }
                                 }
                             }
                             Err(cli_error) => {
@@ -2080,17 +2121,12 @@ pub async fn upload_folder(sub_matches: &clap::ArgMatches) -> Result<(), crate::
 
     // Calculate total assets processed
     let total_assets = total_entries_count;
-    let skipped_count = total_assets - success_count - error_count;
 
     // Print detailed statistics report
     println!("\n📊 Upload Statistics Report");
     println!("===========================");
     println!("✅ Successfully uploaded: {}", success_count);
-    if skip_existing {
-        println!("⏭️  Skipped (already existed): {}", skipped_count);
-    } else {
-        println!("⏭️  Skipped (already existed): 0");
-    }
+    println!("⏭️  Skipped (already existed): {}", skipped_count);
     if error_count > 0 {
         println!("❌ Failed uploads: {}", error_count);
     } else {

--- a/src/commands/assets.rs
+++ b/src/commands/assets.rs
@@ -254,6 +254,7 @@ pub fn asset_command() -> Command {
                     .action(clap::ArgAction::SetTrue)
                     .help("Perform fuzzy search instead of exact search (default: false, which means exact search with quoted text)"),
             )
+            .arg(limit_parameter())
             .arg(format_with_headers_parameter())
             .arg(format_with_metadata_parameter())  // Add metadata flag to be consistent with other match commands
             .arg(format_pretty_parameter())

--- a/src/commands/params.rs
+++ b/src/commands/params.rs
@@ -130,15 +130,19 @@ pub const FORMAT_XLS: &str = "xls";
 ///
 /// This parameter is used across multiple commands for output formatting.
 pub fn format_parameter() -> Arg {
+    // PCLI2_FORMAT is deliberately NOT bound via clap's .env(): commands
+    // narrow the value parser (e.g. only json/csv), so an env value that is
+    // valid for one command (tree, xls) would hard-fail every other command
+    // at parse time, even without --format on the command line. The env var
+    // is resolved as a soft fallback in format_utils instead.
     Arg::new(PARAMETER_FORMAT)
         .short('f')
         .long(PARAMETER_FORMAT)
         .num_args(1)
         .required(false)
-        .env("PCLI2_FORMAT")
         .default_value("json")
         .global(true)
-        .help("Output data format")
+        .help("Output data format [env: PCLI2_FORMAT=]")
         .value_parser(OutputFormat::names())
 }
 
@@ -158,6 +162,9 @@ pub fn format_with_headers_parameter() -> Arg {
         .action(ArgAction::SetTrue)
         .required(false)
         .env("PCLI2_HEADERS")
+        // Accept 1/0/yes/no/on/off in the env var, not just literal
+        // true/false (PCLI2_HEADERS=1 previously aborted every command).
+        .value_parser(clap::builder::BoolishValueParser::new())
         .help("Format the output with headers")
 }
 

--- a/src/format_utils.rs
+++ b/src/format_utils.rs
@@ -47,16 +47,7 @@ impl FormatParams {
 
     /// Get format with custom default when no format is specified.
     pub fn from_args_with_default(sub_matches: &ArgMatches, default_format: &str) -> FormatParams {
-        let format_str = if let Some(format_val) = sub_matches.get_one::<String>(PARAMETER_FORMAT) {
-            format_val.clone()
-        } else {
-            // Check environment variable first, then use provided default
-            if let Ok(env_format) = std::env::var("PCLI2_FORMAT") {
-                env_format
-            } else {
-                default_format.to_string()
-            }
-        };
+        let format_str = get_format_string_with_default(sub_matches, default_format);
 
         // Extract all format flags consistently
         let with_headers = sub_matches.get_flag(PARAMETER_HEADERS);
@@ -82,16 +73,29 @@ impl FormatParams {
 }
 
 fn get_format_string(sub_matches: &ArgMatches) -> String {
-    if let Some(format_val) = sub_matches.get_one::<String>(PARAMETER_FORMAT) {
-        format_val.clone()
-    } else {
-        // Check environment variable first, then use default
+    get_format_string_with_default(sub_matches, "json")
+}
+
+/// Resolve the effective format string: an explicit `--format` always wins;
+/// otherwise the `PCLI2_FORMAT` environment variable takes precedence over
+/// the clap default. The env var is intentionally not bound via clap's
+/// `.env()`: commands narrow the allowed formats, so an env value valid for
+/// one command (e.g. `tree`) must not hard-fail every other command at parse
+/// time. Values a command cannot handle fall back downstream.
+fn get_format_string_with_default(sub_matches: &ArgMatches, default_format: &str) -> String {
+    let explicit =
+        sub_matches.value_source(PARAMETER_FORMAT) == Some(clap::parser::ValueSource::CommandLine);
+    if !explicit {
         if let Ok(env_format) = std::env::var("PCLI2_FORMAT") {
-            env_format
-        } else {
-            "json".to_string() // Default format
+            if !env_format.trim().is_empty() {
+                return env_format;
+            }
         }
     }
+    sub_matches
+        .get_one::<String>(PARAMETER_FORMAT)
+        .cloned()
+        .unwrap_or_else(|| default_format.to_string())
 }
 
 /// Builder for format options to make them more flexible and extensible.

--- a/src/http_utils.rs
+++ b/src/http_utils.rs
@@ -210,9 +210,15 @@ impl HttpClient {
         if response.status().is_success() {
             Ok(())
         } else {
-            Err(crate::physna_v3::ApiError::HttpError(
-                response.error_for_status().unwrap_err(),
-            ))
+            // error_for_status() only yields Err for 4xx/5xx; a 1xx/3xx
+            // (e.g. an unfollowed redirect) must not panic on unwrap_err.
+            match response.error_for_status() {
+                Err(e) => Err(crate::physna_v3::ApiError::HttpError(e)),
+                Ok(response) => Err(crate::physna_v3::ApiError::ConflictError(format!(
+                    "Unexpected HTTP status: {}",
+                    response.status()
+                ))),
+            }
         }
     }
 
@@ -275,10 +281,16 @@ impl HttpClient {
                 }
             }
         } else {
-            // For all other errors, return the error status
-            Err(crate::physna_v3::ApiError::HttpError(
-                response.error_for_status().unwrap_err(),
-            ))
+            // For all other errors, return the error status.
+            // error_for_status() only yields Err for 4xx/5xx; a 1xx/3xx
+            // (e.g. an unfollowed redirect) must not panic on unwrap_err.
+            match response.error_for_status() {
+                Err(e) => Err(crate::physna_v3::ApiError::HttpError(e)),
+                Ok(response) => Err(crate::physna_v3::ApiError::ConflictError(format!(
+                    "Unexpected HTTP status: {}",
+                    response.status()
+                ))),
+            }
         }
     }
 }

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -62,9 +62,26 @@ mod implementation {
             &self,
             tenant: &str,
         ) -> Result<(Option<String>, Option<String>, Option<String>), KeyringError> {
-            let access_token = self.get(tenant, "access-token".to_string()).ok().flatten();
-            let client_id = self.get(tenant, "client-id".to_string()).ok().flatten();
-            let client_secret = self.get(tenant, "client-secret".to_string()).ok().flatten();
+            // A keyring ERROR (locked keychain, access denied) is not the same
+            // as "no stored credential": surface it in the log instead of
+            // silently telling the user to log in again.
+            let fetch = |key: &str| match self.get(tenant, key.to_string()) {
+                Ok(value) => value,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to read '{}' for environment '{}' from the system keyring: {}. \
+                         Treating it as absent; if you are already logged in, check that the keychain is unlocked and accessible.",
+                        key,
+                        tenant,
+                        e
+                    );
+                    None
+                }
+            };
+
+            let access_token = fetch("access-token");
+            let client_id = fetch("client-id");
+            let client_secret = fetch("client-secret");
 
             Ok((access_token, client_id, client_secret))
         }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -104,12 +104,10 @@ pub fn convert_metadata_to_json_values(
     let mut json_metadata: HashMap<String, Value> = HashMap::new();
 
     for (key, value) in metadata {
-        // Sanitize the value to remove or replace problematic characters
-        let sanitized_value = sanitize_metadata_value(value);
-
-        // For now, treat all values as strings to avoid type mismatch issues
-        // The API might be expecting string values for all metadata fields
-        json_metadata.insert(key.clone(), Value::String(sanitized_value));
+        // Values are passed through verbatim: rewriting user data (e.g.
+        // substituting Unicode symbols like Ø or °) silently corrupts
+        // engineering metadata. The API accepts UTF-8 strings as-is.
+        json_metadata.insert(key.clone(), Value::String(value.clone()));
     }
 
     json_metadata
@@ -118,7 +116,7 @@ pub fn convert_metadata_to_json_values(
 /// Convert a single metadata value to appropriate JSON type based on the specified meta-type
 ///
 /// This function converts a single metadata value to the appropriate JSON type based on the
-/// provided metadata type (text, number, boolean), with proper sanitization.
+/// provided metadata type (text, number, boolean). Values are never rewritten.
 ///
 /// # Arguments
 /// * `name` - The metadata property name
@@ -165,31 +163,9 @@ pub fn convert_single_metadata_to_json_value(
             // value looks numeric or boolean. The `--type` flag is authoritative, so
             // `--type text --value 100` must produce the string "100" rather than the
             // number 100 (which the API rejects for string-typed metadata fields).
-            let sanitized_value = sanitize_metadata_value(value);
-            serde_json::Value::String(sanitized_value)
+            serde_json::Value::String(value.to_string())
         }
     }
-}
-
-/// Sanitize metadata values to handle special characters that might cause API issues
-///
-/// This function replaces or removes special characters that are known to cause issues
-/// with the Physna API, such as Unicode symbols that might not be properly encoded.
-///
-/// # Arguments
-/// * `value` - The metadata value to sanitize
-///
-/// # Returns
-/// * `String` - The sanitized metadata value
-fn sanitize_metadata_value(value: &str) -> String {
-    value
-        // Replace special Unicode characters with ASCII equivalents
-        .replace('Ø', "O") // Diameter symbol
-        .replace('°', " deg") // Degree symbol
-        .replace('″', "\"") // Double prime (inch symbol)
-        .replace("…", "...") // Ellipsis
-        // Keep other characters as they are
-        .to_string()
 }
 
 #[cfg(test)]
@@ -221,6 +197,22 @@ mod tests {
     fn text_type_preserves_non_numeric_value() {
         let value = convert_single_metadata_to_json_value("test_quantity", "100pcs", "text");
         assert_eq!(value, Value::String("100pcs".to_string()));
+    }
+
+    #[test]
+    fn text_values_are_never_rewritten() {
+        // Regression: values used to be "sanitized" (Ø→O, °→" deg", ″→", …→...),
+        // silently corrupting engineering metadata. Values must round-trip verbatim.
+        let value = convert_single_metadata_to_json_value("Diameter", "Ø25 ±0.1° … ″", "text");
+        assert_eq!(value, Value::String("Ø25 ±0.1° … ″".to_string()));
+
+        let mut map = std::collections::HashMap::new();
+        map.insert("Diameter".to_string(), "Ø25°".to_string());
+        let json = convert_metadata_to_json_values(&map);
+        assert_eq!(
+            json.get("Diameter").unwrap(),
+            &Value::String("Ø25°".to_string())
+        );
     }
 
     #[test]

--- a/src/metadata_cache.rs
+++ b/src/metadata_cache.rs
@@ -20,10 +20,11 @@ pub struct MetadataCache {
     /// Map of tenant ID to cached metadata field list response
     #[serde(rename = "tenantMetadataFields")]
     pub tenant_metadata_fields: HashMap<String, MetadataFieldListResponse>,
-    /// Timestamp when the cache was last updated (for future use)
-    #[serde(rename = "lastUpdated")]
-    #[serde(skip_serializing, skip_deserializing)]
-    pub last_updated: Option<u64>, // We'll track this internally but not serialize it
+    /// Timestamp when the cache was last updated. Persisted: if it were
+    /// reset on every load, `is_expired` could never return true and cached
+    /// entries would be served forever.
+    #[serde(rename = "lastUpdated", default)]
+    pub last_updated: Option<u64>,
 }
 
 impl MetadataCache {
@@ -86,14 +87,9 @@ impl MetadataCache {
 
         if path.exists() {
             let data = fs::read_to_string(path)?;
-            let mut cache: MetadataCache = serde_json::from_str(&data)?;
-            // Set the internal timestamp to current time to indicate when it was loaded
-            cache.last_updated = Some(
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-            );
+            // The persisted timestamp is kept as-is: overwriting it with
+            // "now" on load would make the cache immortal.
+            let cache: MetadataCache = serde_json::from_str(&data)?;
             debug!("Loaded metadata cache from file");
             Ok(cache)
         } else {
@@ -172,10 +168,17 @@ impl MetadataCache {
         // Fetch from API
         let metadata_fields_response = client.get_metadata_fields(tenant_id).await?;
 
-        // Update cache
+        // Update cache, stamping the refresh time so expiry is measured from
+        // this write.
         cache
             .tenant_metadata_fields
             .insert(tenant_id.to_string(), metadata_fields_response.clone());
+        cache.last_updated = Some(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        );
         if let Err(e) = cache.save() {
             warn!("Failed to save metadata cache: {}", e);
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -93,9 +93,38 @@ pub fn normalize_path(path: impl AsRef<str>) -> String {
     out
 }
 
+/// True when `asset_path` refers to the folder itself or anything inside it.
+///
+/// Uses a path-component boundary rather than a bare string prefix:
+/// `/proj-archive/part.stl` is NOT within `/proj`, even though the string
+/// starts with it.
+pub fn path_is_within_folder(asset_path: impl AsRef<str>, folder_path: impl AsRef<str>) -> bool {
+    let folder = normalize_path(folder_path);
+    let asset = normalize_path(asset_path);
+    if folder == "/" {
+        return true;
+    }
+    asset == folder || asset.starts_with(&format!("{}/", folder))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn path_is_within_folder_respects_component_boundaries() {
+        // Regression: `--exclusive` match filtering used a bare string prefix,
+        // so a `/proj` filter leaked matches from sibling `/proj-archive`.
+        assert!(path_is_within_folder("/proj/part.stl", "/proj"));
+        assert!(path_is_within_folder("/proj/sub/part.stl", "/proj"));
+        assert!(path_is_within_folder("/proj", "/proj"));
+        assert!(!path_is_within_folder("/proj-archive/part.stl", "/proj"));
+        assert!(!path_is_within_folder("/proj2/part.stl", "/proj"));
+        // Root contains everything.
+        assert!(path_is_within_folder("/anything/part.stl", "/"));
+        // Paths without leading slashes normalize consistently.
+        assert!(path_is_within_folder("proj/part.stl", "/proj/"));
+    }
 
     #[test]
     fn test_normalize_path_basic_cases() {

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -67,6 +67,10 @@ pub enum ApiError {
     #[error("Path not found: {0}")]
     PathNotFound(String),
 
+    /// A folder path did not resolve to an existing folder
+    #[error("Folder not found: {0}")]
+    FolderNotFound(String),
+
     #[error("Invalid path for asset. Check asset name: {0}")]
     InvalidAssetPath(String),
 
@@ -90,6 +94,25 @@ pub enum ApiError {
         expected_type: String,
         provided_type: String,
     },
+}
+
+impl ApiError {
+    /// True when the error indicates an authentication/authorization failure,
+    /// including a 401/403 that persisted through the automatic token-refresh
+    /// retry (which surfaces as `RetryFailed` rather than `AuthError`).
+    pub fn is_authentication_failure(&self) -> bool {
+        match self {
+            ApiError::AuthError(_) | ApiError::InvalidToken | ApiError::MissingCredentials => true,
+            ApiError::RetryFailed(msg) => {
+                let msg = msg.to_lowercase();
+                msg.contains("401")
+                    || msg.contains("403")
+                    || msg.contains("unauthorized")
+                    || msg.contains("forbidden")
+            }
+            _ => false,
+        }
+    }
 }
 
 pub trait TryDefault: Sized {
@@ -717,68 +740,15 @@ impl PhysnaApiClient {
                                 "Request still failed after token refresh: {} - {}",
                                 retry_status, retry_error_body
                             );
-                            return Err(ApiError::ConflictError(format!(
-                                "HTTP {} - {}",
-                                retry_status, retry_error_body
-                            )));
-                        }
-                    }
-                }
-            } else if status == reqwest::StatusCode::UNAUTHORIZED
-                || status == reqwest::StatusCode::FORBIDDEN
-            {
-                // Handle 401/403 errors as authentication issues
-                debug!(
-                    "Received {} error - treating as authentication error",
-                    status
-                );
-                if self.access_token.is_none() {
-                    return Err(ApiError::AuthError(
-                        "Authentication required: No access token available. Please log in with 'pcli2 auth login'.".to_string()
-                    ));
-                } else {
-                    // Try to refresh the token
-                    debug!("Attempting token refresh for {} error", status);
-                    if let Err(refresh_err) = self.refresh_token().await {
-                        debug!("Token refresh failed for {} error: {}", status, refresh_err);
-                        return Err(ApiError::AuthError(
-                            "Authentication required: Access token may be invalid or expired. Please log in with 'pcli2 auth login'.".to_string()
-                        ));
-                    } else {
-                        // If refresh succeeds, retry the request
-                        debug!(
-                            "Token refreshed successfully, retrying request after {} error",
-                            status
-                        );
-                        let mut retry_request = request_builder(&self.http_client.client); // Access the underlying reqwest client
-
-                        if let Some(token) = &self.access_token {
-                            retry_request =
-                                retry_request.header("Authorization", format!("Bearer {}", token));
-                        }
-
-                        let retry_response = retry_request.send().await?;
-
-                        if retry_response.status().is_success() {
-                            let response = retry_response.text().await?;
-                            match serde_json::from_str::<T>(&response) {
-                                Ok(result) => return Ok(result),
-                                Err(e) => {
-                                    error!("Failed to deserialize response after token refresh: {}. Raw response: {}", e, response);
-                                    return Err(ApiError::JsonError(e));
-                                }
+                            // A 404 that persists with a fresh token is a genuine
+                            // not-found, not a conflict; classify it so callers
+                            // can match on it.
+                            if retry_status == reqwest::StatusCode::NOT_FOUND {
+                                return Err(ApiError::NotFoundError(format!(
+                                    "HTTP {} - {}",
+                                    retry_status, retry_error_body
+                                )));
                             }
-                        } else {
-                            // Even after refresh, the request failed
-                            let retry_status = retry_response.status();
-                            let retry_error_body = retry_response
-                                .text()
-                                .await
-                                .unwrap_or_else(|_| "Unknown error".to_string());
-                            debug!(
-                                "Request still failed after token refresh: {} - {}",
-                                retry_status, retry_error_body
-                            );
                             return Err(ApiError::ConflictError(format!(
                                 "HTTP {} - {}",
                                 retry_status, retry_error_body
@@ -787,6 +757,8 @@ impl PhysnaApiClient {
                     }
                 }
             }
+            // 401/403 cannot reach this branch: they are consumed by the
+            // authentication-retry branch at the top of this function.
 
             // Try to parse the error as JSON to extract a more descriptive message
             if let Ok(error_json) = serde_json::from_str::<serde_json::Value>(&error_body) {
@@ -1589,18 +1561,97 @@ impl PhysnaApiClient {
         Ok(response.into())
     }
 
-    /// This method is a wrapper around get_folder_uuid_by_path(...), but it will return None if the path is the root.
+    /// List ALL direct subfolders of a folder, walking every page.
+    ///
+    /// `get_folder_contents` fetches a single page; callers that treat one
+    /// page as the complete subfolder set silently lose folders (and
+    /// everything beneath them) once a folder has more direct subfolders than
+    /// the page size. This wrapper accumulates every page.
+    pub async fn list_all_subfolders(
+        &mut self,
+        tenant_uuid: &Uuid,
+        folder_uuid: Option<&Uuid>,
+    ) -> Result<crate::model::FolderList, ApiError> {
+        let url = match folder_uuid {
+            Some(folder_uuid) => format!(
+                "{}/tenants/{}/folders/{}/contents",
+                self.base_url, tenant_uuid, folder_uuid
+            ),
+            None => format!(
+                "{}/tenants/{}/folders/root/contents",
+                self.base_url, tenant_uuid
+            ),
+        };
+
+        let mut all_folders: Vec<crate::model::FolderResponse> = Vec::new();
+        let mut page: usize = 1;
+        let per_page: usize = 200;
+
+        loop {
+            let page_str = page.to_string();
+            let per_page_str = per_page.to_string();
+            let query_params = vec![
+                ("contentType", "folders"),
+                ("page", page_str.as_str()),
+                ("perPage", per_page_str.as_str()),
+            ];
+            let paged_url = format!(
+                "{}?{}",
+                url,
+                serde_urlencoded::to_string(&query_params).unwrap()
+            );
+
+            let response: FolderListResponse = self.get(&paged_url).await?;
+            let current_page = response.page_data.current_page;
+            let last_page = response.page_data.last_page;
+            all_folders.extend(response.folders);
+
+            // Stop on the last page, or if the endpoint fails to advance
+            // `current_page` (guard against looping forever on one page).
+            if current_page >= last_page || current_page < page {
+                break;
+            }
+            page = current_page + 1;
+        }
+
+        let total = all_folders.len();
+        Ok(FolderListResponse {
+            folders: all_folders,
+            page_data: crate::model::PageData {
+                total,
+                per_page,
+                current_page: 1,
+                last_page: 1,
+                start_index: 0,
+                end_index: total,
+            },
+        }
+        .into())
+    }
+
+    /// Strictly resolve a folder path to a UUID.
+    ///
+    /// Returns `Ok(None)` ONLY for the root path "/" (which has no UUID).
+    /// A non-root path that does not resolve to an existing folder is an
+    /// error — it must never be silently treated as the root folder, since
+    /// downstream code that matches assets by name within the resolved
+    /// folder could otherwise target a completely different asset.
     pub async fn resolve_folder_uuid_by_path(
         &mut self,
         tenant_uuid: &Uuid,
         folder_path: &str,
     ) -> Result<Option<Uuid>, ApiError> {
-        if folder_path.eq("/") {
+        let normalized_path = crate::model::normalize_path(folder_path);
+        if normalized_path == "/" {
             Ok(None)
         } else {
-            Ok(self
+            match self
                 .get_folder_uuid_by_path(tenant_uuid, folder_path)
-                .await?)
+                .await?
+            {
+                Some(uuid) => Ok(Some(uuid)),
+                None => Err(ApiError::FolderNotFound(folder_path.to_string())),
+            }
         }
     }
 
@@ -2183,63 +2234,9 @@ impl PhysnaApiClient {
                 status, error_body
             );
 
-            // Handle 401/403 errors as authentication issues
-            if status == reqwest::StatusCode::UNAUTHORIZED
-                || status == reqwest::StatusCode::FORBIDDEN
-            {
-                debug!(
-                    "Received {} error - treating as authentication error",
-                    status
-                );
-                if self.access_token.is_none() {
-                    return Err(ApiError::AuthError(
-                        "Authentication required: No access token available. Please log in with 'pcli2 auth login'.".to_string()
-                    ));
-                } else {
-                    // Try to refresh the token
-                    debug!("Attempting token refresh for {} error", status);
-                    if let Err(refresh_err) = self.refresh_token().await {
-                        debug!("Token refresh failed for {} error: {}", status, refresh_err);
-                        return Err(ApiError::AuthError(
-                            "Authentication required: Access token may be invalid or expired. Please log in with 'pcli2 auth login'.".to_string()
-                        ));
-                    } else {
-                        // If refresh succeeds, retry the request
-                        debug!(
-                            "Token refreshed successfully, retrying request after {} error",
-                            status
-                        );
-                        let mut retry_request = request_builder(&self.http_client.client); // Access the underlying reqwest client
-
-                        if let Some(token) = &self.access_token {
-                            retry_request =
-                                retry_request.header("Authorization", format!("Bearer {}", token));
-                        }
-
-                        let retry_response = retry_request.send().await?;
-
-                        if retry_response.status().is_success() {
-                            // Success after retry
-                            return Ok(());
-                        } else {
-                            // Even after refresh, the request failed
-                            let retry_status = retry_response.status();
-                            let retry_error_body = retry_response
-                                .text()
-                                .await
-                                .unwrap_or_else(|_| "Unknown error".to_string());
-                            debug!(
-                                "Request still failed after token refresh: {} - {}",
-                                retry_status, retry_error_body
-                            );
-                            return Err(ApiError::ConflictError(format!(
-                                "HTTP {} - {}",
-                                retry_status, retry_error_body
-                            )));
-                        }
-                    }
-                }
-            } else if status == reqwest::StatusCode::NOT_FOUND {
+            // 401/403 cannot reach this point: they are consumed by the
+            // authentication-retry branch at the top of this function.
+            if status == reqwest::StatusCode::NOT_FOUND {
                 // Handle 404 errors that might be due to authentication issues
                 debug!("Received 404 error, checking if it's an authentication issue");
                 if self.access_token.is_none() {
@@ -2369,7 +2366,9 @@ impl PhysnaApiClient {
         tenant_uuid: &Uuid,
         file_path: &Path,
         asset_path: &String,
-        folder_uuid: &Uuid,
+        // Kept for API stability; the upload targets the folder via the full
+        // asset path (`createMissingFolders=true`), not a folder id.
+        _folder_uuid: &Uuid,
         metadata: Option<&std::collections::HashMap<String, serde_json::Value>>,
     ) -> Result<crate::model::Asset, ApiError> {
         trace!("Creating new asset by uploading a file...");
@@ -2462,15 +2461,16 @@ impl PhysnaApiClient {
                 )
                 .unwrap();
 
-            // Build the multipart form with file part and required parameters
-            let mut retry_form = reqwest::multipart::Form::new()
+            // Build the retry form IDENTICALLY to the original attempt: the
+            // retry previously sent createMissingFolders="" plus an extra
+            // folderId field, so an upload that merely hit an expired token
+            // could behave differently (e.g. fail to create missing folders)
+            // on the retry.
+            let retry_form = reqwest::multipart::Form::new()
                 .part("file", retry_file_part)
                 .text("path", asset_path.clone()) // Use the full asset path including folder
                 .text("metadata", metadata_json.clone())
-                .text("createMissingFolders", ""); // Empty createMissingFolders as in the working example
-
-            // Add folder ID if provided
-            retry_form = retry_form.text("folderId", folder_uuid.to_string());
+                .text("createMissingFolders", "true"); // Enable creating missing folders
 
             debug!("Retrying asset creation with path: {}", asset_path);
 
@@ -2643,8 +2643,21 @@ impl PhysnaApiClient {
         let mut page = 1;
         let per_page = 100; // Larger page size for efficiency
 
+        // Hard limit to prevent runaway pagination if the server misbehaves,
+        // consistent with part_search and visual_search.
+        let max_pages_limit = 1000;
+
         loop {
             debug!("Fetching page {} of geometric search results", page);
+
+            if page > max_pages_limit {
+                eprintln!(
+                    "⚠️  Warning: geometric search results truncated at {} matches ({}-page safety limit); results are incomplete",
+                    all_matches.len(),
+                    max_pages_limit
+                );
+                break;
+            }
 
             // Build request body with the correct structure
             let body = serde_json::json!({
@@ -2673,21 +2686,30 @@ impl PhysnaApiClient {
                             page_data.current_page, page_data.last_page, page_data.total
                         );
 
+                        // Guard against the endpoint failing to advance
+                        // `current_page` (would otherwise loop forever
+                        // re-appending duplicate matches).
+                        let stalled = page_data.current_page < page;
+                        let last_page_reached = page_data.current_page >= page_data.last_page;
+
                         // Add matches from this page to our collection
                         all_matches.extend(response.matches);
 
-                        // Check if we've reached the last page
-                        if page_data.current_page >= page_data.last_page {
-                            debug!("Reached last page of results");
+                        if last_page_reached || stalled {
+                            debug!("Reached last page of results (stalled: {})", stalled);
                             break;
                         }
 
                         // Move to next page
                         page += 1;
                     } else {
-                        // No pagination data - just return the response as-is
-                        debug!("No pagination data in response, returning single page");
-                        return Ok(response);
+                        // No pagination data - the endpoint returned everything
+                        // at once. Keep this page's matches together with any
+                        // previously accumulated pages instead of discarding
+                        // them.
+                        debug!("No pagination data in response, returning accumulated matches");
+                        all_matches.extend(response.matches);
+                        break;
                     }
                 }
                 Err(e) => {
@@ -2803,15 +2825,19 @@ impl PhysnaApiClient {
 
         // Track the maximum last_page value seen to prevent infinite loops
         let mut max_last_page_seen = 0;
-        let max_pages_limit = 50; // Hard limit to prevent excessive API calls
+        // Hard limit to prevent excessive API calls; aligned with
+        // visual_search (1000 pages) so large result sets aren't cut short.
+        let max_pages_limit = 1000;
 
         loop {
             debug!("Fetching page {} of part search results", page);
 
-            // Check if we've hit the hard limit
+            // Check if we've hit the hard limit. Truncation must be visible
+            // to the user, not just a debug log.
             if page > max_pages_limit {
-                debug!(
-                    "Reached hard page limit of {}, stopping to prevent excessive API calls",
+                eprintln!(
+                    "⚠️  Warning: part search results truncated at {} matches ({}-page safety limit); results are incomplete",
+                    all_matches.len(),
                     max_pages_limit
                 );
                 break;
@@ -2864,9 +2890,13 @@ impl PhysnaApiClient {
                         // Move to next page
                         page += 1;
                     } else {
-                        // No pagination data - just return the response as-is
-                        debug!("No pagination data in response, returning single page");
-                        return Ok(response);
+                        // No pagination data - the endpoint returned everything
+                        // at once. Keep this page's matches together with any
+                        // previously accumulated pages instead of discarding
+                        // them.
+                        debug!("No pagination data in response, returning accumulated matches");
+                        all_matches.extend(response.matches);
+                        break;
                     }
                 }
                 Err(e) => {
@@ -3060,9 +3090,13 @@ impl PhysnaApiClient {
     /// The search looks through asset names, paths, and associated metadata to find relevant matches.
     /// The search results are ordered by relevance as determined by the text search algorithm.
     ///
+    /// Results are accumulated across pages until `limit` matches are
+    /// collected or the last page is reached, mirroring `visual_search`.
+    ///
     /// # Arguments
     /// * `tenant_uuid` - The UUID of the tenant to search within
     /// * `text_query` - The text query to search for in assets
+    /// * `limit` - Maximum number of matches to return
     ///
     /// # Returns
     /// * `Ok(TextSearchResponse)` - The search results with text-matched assets
@@ -3071,60 +3105,107 @@ impl PhysnaApiClient {
         &mut self,
         tenant_uuid: &Uuid,
         text_query: &str,
+        limit: usize,
     ) -> Result<crate::model::TextSearchResponse, ApiError> {
         debug!(
-            "Starting text search for tenant_uuid: {}, query: {}",
-            tenant_uuid, text_query
+            "Starting text search for tenant_uuid: {}, query: {}, limit: {}",
+            tenant_uuid, text_query, limit
         );
         let url = format!(
             "{}/tenants/{}/assets/text-search",
             self.base_url, tenant_uuid
         );
 
-        // Text search - get first page with 50 results (top matches)
-        let page = 1;
-        let per_page = 50; // Reasonable page size for text search
+        // Accumulate matches across pages until we have at least `limit`.
+        let mut all_matches = Vec::new();
+        let mut page = 1;
+        // Request only as many per page as we need (capped at the endpoint
+        // maximum of 1000), so a small limit costs a single request.
+        let per_page = limit.clamp(1, 1000);
 
-        // Build request body with the correct structure
-        let body = serde_json::json!({
-            "page": page,
-            "perPage": per_page,
-            "searchQuery": text_query,
-            "filters": {
-                "folders": [],
-                "metadata": {},
-                "extensions": []  // Empty array as requested
-            }
-        });
+        // Track the maximum last_page value seen to prevent infinite loops.
+        let mut max_last_page_seen = 0;
+        let max_pages_limit = 1000; // Hard limit to prevent excessive API calls
 
-        debug!("Sending text search request to: {}", url);
-        // Execute POST request
-        let result: Result<crate::model::TextSearchResponse, ApiError> =
-            self.post(&url, &body).await;
-
-        match result {
-            Ok(mut response) => {
-                // Limit results to 50 to ensure we don't exceed expected page size
-                if response.matches.len() > 50 {
-                    response.matches.truncate(50);
-                }
-
-                // Clear pagination data since we're only getting the first page
-                response.page_data = None;
-
+        loop {
+            if page > max_pages_limit {
                 debug!(
-                    "Text search completed for query: '{}' with {} total matches",
-                    text_query,
-                    response.matches.len()
+                    "Reached hard page limit of {}, stopping text search pagination",
+                    max_pages_limit
                 );
-                Ok(response)
+                break;
             }
-            Err(e) => {
-                // Return error immediately
-                debug!("Text search failed: {}", e);
-                Err(e)
+
+            let body = serde_json::json!({
+                "page": page,
+                "perPage": per_page,
+                "searchQuery": text_query,
+                "filters": {
+                    "folders": [],
+                    "metadata": {},
+                    "extensions": []
+                }
+            });
+
+            debug!("Sending text search request to: {}", url);
+            let result: Result<crate::model::TextSearchResponse, ApiError> =
+                self.post(&url, &body).await;
+
+            match result {
+                Ok(response) => {
+                    if let Some(page_data) = &response.page_data {
+                        debug!(
+                            "Page {}/{} with {} total matches",
+                            page_data.current_page, page_data.last_page, page_data.total
+                        );
+
+                        if page_data.last_page > max_last_page_seen {
+                            max_last_page_seen = page_data.last_page;
+                        }
+
+                        all_matches.extend(response.matches);
+
+                        // Stop once we have enough results, reach the last page,
+                        // or the endpoint fails to advance `current_page` (guard
+                        // against looping forever on the same page).
+                        if all_matches.len() >= limit
+                            || page_data.current_page >= page_data.last_page
+                            || page_data.current_page < page
+                        {
+                            break;
+                        }
+
+                        page += 1;
+                    } else {
+                        // No pagination data - return this single page, capped at
+                        // the requested limit.
+                        debug!("No pagination data in text search response, returning single page");
+                        let mut response = response;
+                        response.matches.truncate(limit);
+                        return Ok(response);
+                    }
+                }
+                Err(e) => {
+                    debug!("Text search failed: {}", e);
+                    return Err(e);
+                }
             }
         }
+
+        // The last page may overshoot the requested limit; cap it here.
+        all_matches.truncate(limit);
+
+        debug!(
+            "Text search completed for query: '{}' with {} total matches",
+            text_query,
+            all_matches.len()
+        );
+
+        Ok(crate::model::TextSearchResponse {
+            matches: all_matches,
+            page_data: None, // We've aggregated all pages
+            filter_data: None,
+        })
     }
 
     /// Create multiple assets by uploading files matching a glob pattern
@@ -3203,12 +3284,38 @@ impl PhysnaApiClient {
         let base_url = self.base_url.clone();
         let access_token = self.access_token.clone();
         let client_credentials = self.client_credentials.clone();
+        // The per-file clients must inherit the parent's auth endpoint and
+        // environment: constructing them with defaults would refresh tokens
+        // against the production Cognito URL and save them under the
+        // "default" environment even when another environment is active.
+        let auth_url = self.auth_url.clone();
+        let environment_name = self.environment_name.clone();
         let folder_path = folder_path.map(|s| s.to_string());
 
         debug!(
             "Folder path for batch upload: {:?}, folder ID: {:?}",
             folder_path, folder_uuid
         );
+
+        // Both a folder path and a folder UUID are required by the per-file
+        // upload; validate up front instead of unwrapping inside spawned
+        // tasks, where a panic would be silently swallowed by the join.
+        let folder_path = match folder_path {
+            Some(p) => p,
+            None => {
+                return Err(ApiError::InvalidParameterError(
+                    "A folder path is required for batch upload".to_string(),
+                ))
+            }
+        };
+        let folder_uuid_required = match folder_uuid {
+            Some(u) => *u,
+            None => {
+                return Err(ApiError::InvalidParameterError(
+                    "A folder UUID is required for batch upload".to_string(),
+                ))
+            }
+        };
 
         // Use a semaphore to control concurrency
         use tokio::sync::Semaphore;
@@ -3221,9 +3328,6 @@ impl PhysnaApiClient {
         >(paths.len().max(1));
 
         // Process each file with controlled concurrency
-        // Convert folder_uuid to owned value to avoid lifetime issues
-        let folder_uuid_owned = folder_uuid.cloned();
-
         let tasks: Vec<_> = paths
             .into_iter()
             .map(|path_buf| {
@@ -3232,8 +3336,10 @@ impl PhysnaApiClient {
                 let base_url = base_url.clone();
                 let access_token = access_token.clone();
                 let client_credentials = client_credentials.clone();
+                let auth_url = auth_url.clone();
+                let environment_name = environment_name.clone();
                 let folder_path = folder_path.clone();
-                let folder_uuid = folder_uuid_owned;
+                let folder_uuid = folder_uuid_required;
                 let progress_bar = progress_bar.clone();
                 let tenant_uuid = *tenant_uuid;
                 let semaphore = semaphore.clone();
@@ -3262,8 +3368,13 @@ impl PhysnaApiClient {
                     };
 
                     // Create a new client that shares the HTTP client to leverage connection pooling
-                    let base_client =
+                    let mut base_client =
                         PhysnaApiClient::new_with_shared_http_client(shared_http_client, base_url);
+                    // Inherit the parent's auth endpoint and environment so
+                    // mid-batch token refreshes hit the right Cognito URL and
+                    // persist under the active environment.
+                    base_client.auth_url = auth_url;
+                    base_client.environment_name = environment_name;
                     let mut client = base_client.for_upload_operations(); // Use upload-optimized timeout
 
                     if let Some(token) = access_token {
@@ -3274,14 +3385,13 @@ impl PhysnaApiClient {
                     }
 
                     // Upload the file
-                    let asset_path =
-                        format!("{}/{}", folder_path.unwrap(), file_name.to_string_lossy());
+                    let asset_path = format!("{}/{}", folder_path, file_name.to_string_lossy());
                     debug!(
                         "Uploading file: {}, as asset_path: {}, folder_uuid: {:?}",
                         path_str, asset_path, folder_uuid
                     );
                     let result = client
-                        .create_asset(&tenant_uuid, &path_buf, &asset_path, &folder_uuid.unwrap())
+                        .create_asset(&tenant_uuid, &path_buf, &asset_path, &folder_uuid)
                         .await;
 
                     // Update progress bar if present
@@ -3317,9 +3427,12 @@ impl PhysnaApiClient {
             })
             .collect();
 
-        // Wait for all tasks to complete
+        // Wait for all tasks to complete. A panicked task would otherwise be
+        // silently dropped from both the success and failure counts.
         for task in tasks {
-            let _ = task.await;
+            if let Err(join_error) = task.await {
+                tracing::error!("Batch upload task failed to complete: {}", join_error);
+            }
         }
 
         // Drop the original sender so the receiver knows when all tasks are done
@@ -3407,7 +3520,7 @@ impl PhysnaApiClient {
         let encoded_asset_path = urlencoding::encode(physna_path);
 
         let url = format!(
-            "{}/tenants/{}/assets/{}/dependencies?page={}&per_page={}",
+            "{}/tenants/{}/assets/{}/dependencies?page={}&perPage={}",
             self.base_url, tenant_uuid, encoded_asset_path, page, per_page
         );
         debug!("Dependencies request URL: {}", url);
@@ -3438,51 +3551,11 @@ impl PhysnaApiClient {
                     Err(ApiError::NotFoundError(error_msg))
                 }
             }
-            Err(ApiError::HttpError(reqwest_err)) => {
-                // Check if this is a 404 error which might indicate no dependencies
-                if reqwest_err.status() == Some(reqwest::StatusCode::NOT_FOUND) {
-                    // Return an empty response instead of an error
-                    debug!("Asset has no dependencies (404 received), returning empty response");
-                    Ok(AssetDependenciesResponse {
-                        dependencies: vec![],
-                        page_data: crate::model::PageData {
-                            current_page: page,
-                            per_page,
-                            total: 0,
-                            last_page: 1,
-                            start_index: 0,
-                            end_index: 0,
-                        },
-                        original_asset_path: physna_path.to_string(),
-                    })
-                } else {
-                    // Re-raise the original error if it's not a 404
-                    Err(ApiError::HttpError(reqwest_err))
-                }
-            }
-            Err(ApiError::AuthError(msg)) => {
-                // Check if the auth error message contains indication of "no dependencies"
-                // This happens when the 404 gets converted to auth error during token refresh
-                if msg.contains("No dependencies found for asset") || msg.contains("404") {
-                    debug!("Asset has no dependencies (converted auth error), returning empty response");
-                    Ok(AssetDependenciesResponse {
-                        dependencies: vec![],
-                        page_data: crate::model::PageData {
-                            current_page: page,
-                            per_page,
-                            total: 0,
-                            last_page: 1,
-                            start_index: 0,
-                            end_index: 0,
-                        },
-                        original_asset_path: physna_path.to_string(),
-                    })
-                } else {
-                    // Re-raise the auth error if it's not related to missing dependencies
-                    Err(ApiError::AuthError(msg))
-                }
-            }
-            Err(e) => Err(e), // Re-raise any other error
+            // A genuine 404 (e.g. the asset itself no longer exists) and auth
+            // errors propagate as errors. They must NOT be swallowed into an
+            // empty dependency list: only the explicit "No dependencies found"
+            // response above means "this asset has no dependencies".
+            Err(e) => Err(e),
         }
     }
 
@@ -3500,7 +3573,7 @@ impl PhysnaApiClient {
         );
 
         let url = format!(
-            "{}/tenants/{}/assets/{}/dependencies?page={}&per_page={}",
+            "{}/tenants/{}/assets/{}/dependencies?page={}&perPage={}",
             self.base_url, tenant_uuid, asset_uuid, page, per_page
         );
         debug!("Dependencies request URL: {}", url);
@@ -3531,51 +3604,11 @@ impl PhysnaApiClient {
                     Err(ApiError::NotFoundError(error_msg))
                 }
             }
-            Err(ApiError::HttpError(reqwest_err)) => {
-                // Check if this is a 404 error which might indicate no dependencies
-                if reqwest_err.status() == Some(reqwest::StatusCode::NOT_FOUND) {
-                    // Return an empty response instead of an error
-                    debug!("Asset has no dependencies (404 received), returning empty response");
-                    Ok(AssetDependenciesResponse {
-                        dependencies: vec![],
-                        page_data: crate::model::PageData {
-                            current_page: page,
-                            per_page,
-                            total: 0,
-                            last_page: 1,
-                            start_index: 0,
-                            end_index: 0,
-                        },
-                        original_asset_path: asset_uuid.to_string(), // Store UUID as string for consistency
-                    })
-                } else {
-                    // Re-raise the original error if it's not a 404
-                    Err(ApiError::HttpError(reqwest_err))
-                }
-            }
-            Err(ApiError::AuthError(msg)) => {
-                // Check if the auth error message contains indication of "no dependencies"
-                // This happens when the 404 gets converted to auth error during token refresh
-                if msg.contains("No dependencies found for asset") || msg.contains("404") {
-                    debug!("Asset has no dependencies (converted auth error), returning empty response");
-                    Ok(AssetDependenciesResponse {
-                        dependencies: vec![],
-                        page_data: crate::model::PageData {
-                            current_page: page,
-                            per_page,
-                            total: 0,
-                            last_page: 1,
-                            start_index: 0,
-                            end_index: 0,
-                        },
-                        original_asset_path: asset_uuid.to_string(), // Store UUID as string for consistency
-                    })
-                } else {
-                    // Re-raise the auth error if it's not related to missing dependencies
-                    Err(ApiError::AuthError(msg))
-                }
-            }
-            Err(e) => Err(e), // Re-raise any other error
+            // A genuine 404 (e.g. the asset itself no longer exists) and auth
+            // errors propagate as errors. They must NOT be swallowed into an
+            // empty dependency list: only the explicit "No dependencies found"
+            // response above means "this asset has no dependencies".
+            Err(e) => Err(e),
         }
     }
 
@@ -3591,32 +3624,59 @@ impl PhysnaApiClient {
             .get_asset_by_path(tenant_uuid, asset_path.as_ref())
             .await?;
 
-        // Then use the UUID-based pagination method with default page values
-        self.get_asset_dependencies_by_uuid_with_pagination(
-            tenant_uuid,
-            &asset.uuid(),
-            1,   // page 1
-            100, // 100 per page
-        )
-        .await
+        self.get_asset_dependencies_list_by_uuid(tenant_uuid, &asset.uuid())
+            .await
     }
 
     /// Public method to get asset dependencies list by UUID
     ///
-    /// This method returns the raw dependencies response instead of building an assembly tree
+    /// This method returns the raw dependencies response instead of building
+    /// an assembly tree. All pages are accumulated: an asset with more direct
+    /// dependencies than one page returns the complete list.
     pub async fn get_asset_dependencies_list_by_uuid(
         &mut self,
         tenant_uuid: &Uuid,
         asset_uuid: &Uuid,
     ) -> Result<AssetDependenciesResponse, ApiError> {
-        // Use the UUID-based pagination method with default page values
-        self.get_asset_dependencies_by_uuid_with_pagination(
-            tenant_uuid,
-            asset_uuid,
-            1,   // page 1
-            100, // 100 per page
-        )
-        .await
+        let mut page: usize = 1;
+        let per_page: usize = 100;
+        let mut all_dependencies = Vec::new();
+
+        loop {
+            let response = self
+                .get_asset_dependencies_by_uuid_with_pagination(
+                    tenant_uuid,
+                    asset_uuid,
+                    page,
+                    per_page,
+                )
+                .await?;
+
+            let current_page = response.page_data.current_page;
+            let last_page = response.page_data.last_page;
+            all_dependencies.extend(response.dependencies);
+
+            // Stop on the last page, or if the endpoint fails to advance
+            // `current_page` (guard against looping forever on one page).
+            if current_page >= last_page || current_page < page {
+                break;
+            }
+            page = current_page + 1;
+        }
+
+        let total = all_dependencies.len();
+        Ok(AssetDependenciesResponse {
+            dependencies: all_dependencies,
+            page_data: crate::model::PageData {
+                total,
+                per_page,
+                current_page: 1,
+                last_page: 1,
+                start_index: 0,
+                end_index: total,
+            },
+            original_asset_path: String::new(),
+        })
     }
 
     #[async_recursion]
@@ -3953,13 +4013,13 @@ impl PhysnaApiClient {
 
         // Initialize pagination variables
         let mut page: usize = 1;
-        let per_page: usize = 100; // Reasonable page size for asset listings
+        let per_page: usize = 200; // Reasonable page size for asset listings
         let mut all_assets: Vec<Asset> = Vec::new();
 
         // Loop through all pages to get all assets with the specified state
         loop {
             let url = format!(
-                "{}/tenants/{}/assets/state/{}?page={}&per_page={}",
+                "{}/tenants/{}/assets/state/{}?page={}&perPage={}",
                 self.base_url, tenant_uuid, state, page, per_page
             );
             debug!("Assets by state request URL: {}", url);
@@ -4008,9 +4068,15 @@ impl PhysnaApiClient {
             // Increment the page number to avoid infinite loops
             page += 1;
 
-            // Safety check to prevent infinite loops in case of API issues
+            // Safety check to prevent infinite loops in case of API issues.
+            // If a tenant legitimately exceeds this, the truncation must be
+            // visible to the user, not just a debug log.
             if page > 1000 {
-                // Arbitrary large number to prevent infinite loops
+                eprintln!(
+                    "⚠️  Warning: asset listing for state '{}' was truncated at {} assets (1000-page safety limit); results are incomplete",
+                    state,
+                    all_assets.len()
+                );
                 debug!("Reached maximum page limit (1000) while fetching assets by state: {} for tenant: {}", state, tenant_uuid);
                 break;
             }
@@ -4451,24 +4517,52 @@ impl PhysnaApiClient {
 
             // Create an appropriate error based on the response status
             match status {
-                reqwest::StatusCode::UNAUTHORIZED => {
-                    // Check if we have an access token - if not, this is a general auth error
-                    if self.access_token.is_none() {
-                        Err(ApiError::AuthError(format!("Authentication required for asset {}: No access token available. Please log in with 'pcli2 auth login'.", asset_display)))
-                    } else {
-                        Err(ApiError::AuthError(format!("Unauthorized access for asset {}: Access token may have expired or is invalid.", asset_display)))
+                reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
+                    // Refresh the token and retry once, consistent with the
+                    // non-streaming download_asset (previously this variant
+                    // failed terminally on an expired token).
+                    debug!(
+                        "Received {} for asset stream, attempting token refresh",
+                        status
+                    );
+                    self.refresh_token().await.map_err(|_| {
+                        ApiError::AuthError(format!(
+                            "Authentication required for asset {}: Access token may have expired or is invalid. Please log in with 'pcli2 auth login'.",
+                            asset_display
+                        ))
+                    })?;
+
+                    if let Err(e) = self.save_current_token_to_keyring_internal() {
+                        debug!("Failed to save refreshed token to keyring: {}", e);
                     }
-                }
-                reqwest::StatusCode::FORBIDDEN => {
-                    // Check if we have an access token - if not, this is a general auth error
-                    if self.access_token.is_none() {
-                        Err(ApiError::AuthError(format!("Authentication required for asset {}: No access token available. Please log in with 'pcli2 auth login'.", asset_display)))
+
+                    let token = self.access_token.as_ref().ok_or_else(|| {
+                        ApiError::AuthError(format!(
+                            "Authentication required for asset {}: No access token available. Please log in with 'pcli2 auth login'.",
+                            asset_display
+                        ))
+                    })?;
+
+                    let retry_response = self
+                        .http_client
+                        .client
+                        .get(&url)
+                        .header("Authorization", format!("Bearer {}", token))
+                        .send()
+                        .await?;
+
+                    if retry_response.status().is_success() {
+                        Ok(retry_response.bytes_stream())
                     } else {
-                        Err(ApiError::AuthError(format!("Access forbidden for asset {}: You don't have permission to download this asset.", asset_display)))
+                        let retry_status = retry_response.status();
+                        Err(ApiError::AuthError(format!(
+                            "Download failed for asset {} after token refresh (HTTP {}).",
+                            asset_display, retry_status
+                        )))
                     }
                 }
                 reqwest::StatusCode::NOT_FOUND => {
-                    Err(ApiError::ConflictError(format!("Asset not found - the asset {} may have been deleted or the path is incorrect. API Response: {}", asset_display, error_body)))
+                    Err(ApiError::NotFoundError(format!("Asset not found - the asset {} may have been deleted or the path is incorrect. API Response: {}", asset_display, error_body)))
                 }
                 _ => {
                     // For other error statuses, we return the error body that we captured earlier
@@ -4803,9 +4897,12 @@ impl PhysnaApiClient {
                 // Move to next page
                 page += 1;
             } else {
-                // No pagination data - just return the response as-is
-                debug!("No pagination data in response, returning single page");
-                return Ok(response);
+                // No pagination data - the endpoint returned everything at
+                // once. The page's users were already moved into `all_users`
+                // above, so break and return the accumulated list (returning
+                // `response` here would return an EMPTY user list).
+                debug!("No pagination data in response, returning accumulated users");
+                break;
             }
         }
 

--- a/src/tenant_cache.rs
+++ b/src/tenant_cache.rs
@@ -194,12 +194,27 @@ impl TenantCache {
 
     /// Invalidate cache for all tenants
     ///
-    /// This method clears the cached tenant list.
+    /// This method clears the cached tenant list for EVERY environment.
+    /// Tenant cache files are per-environment (`tenant_cache_<env>.json`);
+    /// removing only the active environment's file would leave other
+    /// environments serving stale tenant lists after a "cache cleared"
+    /// confirmation.
     pub fn invalidate_all() -> Result<(), CacheError> {
-        let path = Self::get_cache_file_path()?;
-        if path.exists() {
-            std::fs::remove_file(&path)?;
-            trace!("Invalidated all tenant cache");
+        let active_path = Self::get_cache_file_path()?;
+        let cache_dir = active_path
+            .parent()
+            .ok_or_else(|| CacheError::Other("Could not determine cache directory".to_string()))?;
+
+        if cache_dir.exists() {
+            for entry in std::fs::read_dir(cache_dir)? {
+                let entry = entry?;
+                let name = entry.file_name();
+                let name = name.to_string_lossy().to_string();
+                if name.starts_with("tenant_cache_") && name.ends_with(".json") {
+                    std::fs::remove_file(entry.path())?;
+                    trace!("Removed tenant cache file: {}", name);
+                }
+            }
         }
         Ok(())
     }

--- a/tests/folder_resolution_test.rs
+++ b/tests/folder_resolution_test.rs
@@ -1,0 +1,78 @@
+//! Tests for strict folder path resolution.
+//!
+//! `resolve_folder_uuid_by_path` must return `None` ONLY for the root path
+//! "/". A non-root path that doesn't resolve to an existing folder must be an
+//! error: it previously fell through as `None`, which downstream code treated
+//! as "the root folder", so commands like `asset delete --path
+//! /Typo/part.stl` could resolve — and delete — a same-named asset at the
+//! root instead of failing.
+
+use mockito::Matcher;
+use pcli2::physna_v3::{ApiError, PhysnaApiClient};
+use uuid::Uuid;
+
+fn folders_body(tenant: &Uuid) -> String {
+    format!(
+        r#"{{
+            "folders": [
+                {{
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "tenantId": "{}",
+                    "name": "Existing",
+                    "createdAt": "2026-01-01T00:00:00Z",
+                    "updatedAt": "2026-01-01T00:00:00Z",
+                    "assetsCount": 0,
+                    "foldersCount": 0
+                }}
+            ],
+            "pageData": {{"total":1,"perPage":200,"currentPage":1,"lastPage":1,"startIndex":0,"endIndex":0}}
+        }}"#,
+        tenant
+    )
+}
+
+#[tokio::test]
+async fn nonexistent_folder_path_is_an_error_not_root() {
+    // Isolate the folder cache to a temp dir for this test process.
+    let cache_dir = std::env::temp_dir().join(format!("pcli2-test-cache-{}", std::process::id()));
+    std::env::set_var("PCLI2_CACHE_DIR", &cache_dir);
+
+    let mut server = mockito::Server::new_async().await;
+    let tenant = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+
+    let _folders = server
+        .mock("GET", format!("/tenants/{}/folders", tenant).as_str())
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(folders_body(&tenant))
+        .create_async()
+        .await;
+
+    let mut client = PhysnaApiClient::new().with_base_url(server.url());
+
+    // Root resolves to None (the root has no UUID).
+    let root = client.resolve_folder_uuid_by_path(&tenant, "/").await;
+    assert!(matches!(root, Ok(None)));
+
+    // An existing folder resolves to its UUID.
+    let existing = client
+        .resolve_folder_uuid_by_path(&tenant, "/Existing")
+        .await
+        .unwrap();
+    assert_eq!(
+        existing,
+        Some(Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap())
+    );
+
+    // A nonexistent folder is an ERROR — never silently the root.
+    let missing = client
+        .resolve_folder_uuid_by_path(&tenant, "/DoesNotExist")
+        .await;
+    match missing {
+        Err(ApiError::FolderNotFound(path)) => assert_eq!(path, "/DoesNotExist"),
+        other => panic!("expected FolderNotFound error, got {:?}", other),
+    }
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}


### PR DESCRIPTION
## Summary

Patch release containing all fixes from the deep code review, spanning four areas:

**Wrong-target / data integrity**
- Nonexistent folder paths error instead of silently resolving to the root folder (where name-only matching could delete or modify the wrong asset). Absent or `/` folder path still means root.
- Folder create/delete/rename/move invalidate the folder cache.
- Metadata values are never rewritten (`Ø`, `°`, `″`, `…` were silently substituted before).

**Pagination**
- `per_page`→`perPage` on three endpoints (API ignored `per_page`, serving 20/page).
- `asset match text` paginates fully with a new `--limit` flag (was silently capped at 50).
- Truncation warnings on all pagination safety caps; subfolder page-walking in folder download/thumbnail; empty user-list fix; stall guards in search loops.

**Auth / error handling**
- Persistent 404 after token refresh classified as not-found; dependency queries no longer swallow auth errors into an empty BOM.
- Batch metadata updates abort on persistent auth failure instead of retrying every row.
- Upload auth-retry sends the identical multipart form; batch-upload clients inherit auth URL and environment; keyring errors are logged.

**CLI correctness**
- `--exclusive` respects folder boundaries; `--resume` skips extracted assemblies; stale temp files can't leak into `download-folder` ZIPs; honest skip/success statistics and exit codes; `PCLI2_FORMAT`/`PCLI2_HEADERS` env handling; three crash fixes.

## Test plan

- [x] fmt, clippy `-D warnings` clean; 220 tests pass (5 new: folder resolution, pagination boundary, value integrity, UTF-8 header, path-boundary)
- [x] Live tenant verification: mistyped path errors with suggestions, delete-twice reports "Folder not found", env-var scenarios, existing resolution unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)