### PR TITLE
Release v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-13
+
+### Added
+- **`tenant metadata list` command** - Lists every metadata field registered in the tenant along with its data type (`text`, `number`, `boolean`, `url`). Supports `--format json|csv|tree` (alias `ls`). The CSV output uses the same column header as the classic `asset metadata create-batch` input (`ASSET_PATH,NAME,VALUE,TYPE`), with `NAME` and `TYPE` filled from the registry and `ASSET_PATH`/`VALUE` left blank — so a listing can be saved and turned directly into a batch-upload template.
+- **Optional `TYPE` column for `asset metadata create-batch`** - The classic CSV layout accepts an optional fourth `TYPE` column (`text`, `number`, `boolean`, or `url`; default `text`), applied per row. It sets the type used when *registering a new* metadata field; for a field that already exists, its registered type stays authoritative. The `url` type is now also accepted by single `asset metadata create --type`.
+
+### Fixed
+- **Batch metadata upload no longer fails on non-text fields** - `asset metadata create-batch` sent every CSV value as a string, so `number`, `boolean`, and `url` fields were rejected with a "type mismatch" error. Values are now automatically coerced to each field's registered type (e.g. `18` for a number field, `true` for a boolean, a URL string for a url field), so existing typed fields populate without any extra configuration. A value that cannot be represented as the field's type (e.g. `N/A` for a number field) is reported as a type conflict.
+- **`/Home` asset paths in batch uploads resolve to the root** - A leading `/Home` (the name Physna shows for the root folder) in an `ASSET_PATH` is normalized to the root, so `/Home/NX/part.prt` and `NX/part.prt` refer to the same asset. Rows that spell the same asset differently now merge onto one asset instead of splitting into separate lookups.
+
+### Changed
+- **`asset metadata create-batch --continue-on-error` also skips metadata failures** - Previously the flag skipped only assets whose path could not be resolved; a failed metadata update or delete (such as a type conflict) always terminated the batch. It now skips the offending asset and continues, consistent with how unresolved paths are handled. Authentication failures remain fatal.
+
 ## [1.10.0] - 2026-07-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.10.0"
+version = "1.11.0"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/README.md
+++ b/README.md
@@ -636,6 +636,7 @@ Quick reference for all available command aliases:
 | `pcli2 tenant list` | `pcli2 tenant ls` |
 | `pcli2 tenant use` | `pcli2 tenant select` |
 | `pcli2 tenant clear` | `pcli2 tenant unset` |
+| `pcli2 tenant metadata list` | `pcli2 tenant metadata ls` |
 
 ### Folder Commands
 | Full Command | Alias |
@@ -813,16 +814,18 @@ The `asset metadata create-batch` command accepts two CSV layouts. The layout is
 **Classic (vertical) format** — one row per asset+field combination:
 
 ```
-ASSET_PATH,NAME,VALUE
-/Root/Folder/Model1.stl,Material,Steel
-/Root/Folder/Model1.stl,Weight,"15.5 kg"
-/Root/Folder/Model2.ipt,Material,Aluminum
-/Root/Folder/Model2.ipt,Supplier,Richardson Electronics
+ASSET_PATH,NAME,VALUE,TYPE
+/Root/Folder/Model1.stl,Material,Steel,text
+/Root/Folder/Model1.stl,Weight,15.5,number
+/Root/Folder/Model2.ipt,Inventory Qty,42,number
+/Root/Folder/Model2.ipt,Supplier Link,https://example.com/,url
 ```
 
-- The first row must contain the headers `ASSET_PATH,NAME,VALUE`
+- The first row must contain the headers `ASSET_PATH,NAME,VALUE`, optionally followed by `TYPE`
 - Each row represents a single metadata field assignment for an asset
 - If an asset has multiple metadata fields to update, include multiple rows with the same `ASSET_PATH` but different `NAME` and `VALUE` combinations
+- **`TYPE`** is optional (default `text`; one of `text`, `number`, `boolean`, `url`) and only sets the type used when *registering a new* field — for an existing field, its registered type is authoritative and `TYPE` is ignored
+- A leading `/Home` in `ASSET_PATH` (Physna's name for the root folder) is treated as the root, so `/Home/NX/part.prt` and `NX/part.prt` refer to the same asset
 
 **UI (horizontal) format** — one row per asset, as exported by the Physna web UI's bulk metadata upload:
 
@@ -838,6 +841,8 @@ path,id,metadata:Material,metadata:Color
 
 In both formats, empty values are skipped by default (existing metadata is left untouched). Pass `--delete-if-empty` to instead delete a metadata field from the asset when the file contains an empty value for it.
 
+**Automatic type coercion**: because a CSV cell is text, each value is coerced to the field's registered type before upload — a `number` field receives `18` (not `"18"`), a `boolean` field accepts `true`/`false`/`yes`/`no`/`1`/`0`, and `text`/`url` fields store the value as a string. A value that cannot be represented as the field's type (e.g. `N/A` for a number field) is a type conflict and is reported as an error.
+
 **General requirements** (both formats):
 - The file must be UTF-8 encoded
 - Values containing commas, quotes, or newlines must be enclosed in double quotes
@@ -845,7 +850,9 @@ In both formats, empty values are skipped by default (existing metadata is left 
 
 **Error Handling**:
 
-By default, the batch stops on the first error and reports how many assets were processed successfully. Pass `--continue-on-error` to skip rows whose `ASSET_PATH` cannot be resolved and continue with the remaining assets. Metadata API failures (e.g. a failed update for a resolved asset) always terminate the batch regardless of the flag, because the API layer already retries transient HTTP failures internally.
+By default, the batch stops on the first error and reports how many assets were processed successfully. Pass `--continue-on-error` to skip the offending asset — whether its `ASSET_PATH` cannot be resolved or its metadata update fails (including a type conflict) — and continue with the remaining assets. Authentication failures always terminate the batch regardless of the flag.
+
+To generate a starting CSV of the fields already registered in the tenant (with their types), use `pcli2 tenant metadata list --format csv --headers` (see [Tenant Commands](#tenant-commands)).
 
 ### Folder Commands
 
@@ -920,12 +927,19 @@ pcli2 folder list --reload --format tree
 Manage tenant-level operations.
 
 ```
-pcli2 tenant list     # List all tenants
-pcli2 tenant get      # Get tenant details
-pcli2 tenant use      # Set the active tenant
-pcli2 tenant current  # Get the active tenant
-pcli2 tenant clear    # Clear the active tenant
-pcli2 tenant state    # Get asset state counts for the current tenant
+pcli2 tenant list           # List all tenants
+pcli2 tenant get            # Get tenant details
+pcli2 tenant use            # Set the active tenant
+pcli2 tenant current        # Get the active tenant
+pcli2 tenant clear          # Clear the active tenant
+pcli2 tenant state          # Get asset state counts for the current tenant
+pcli2 tenant metadata list  # List the tenant's registered metadata fields with their types
+```
+
+The `tenant metadata list` output (CSV) uses the same header as the classic `create-batch` input (`ASSET_PATH,NAME,VALUE,TYPE`) with `NAME` and `TYPE` filled from the registry and `ASSET_PATH`/`VALUE` blank, so it can be saved and turned into a batch-upload template:
+
+```bash
+pcli2 tenant metadata list --format csv --headers > fields.csv
 ```
 
 ### Authentication Commands

--- a/docs/src/metadata-operations.md
+++ b/docs/src/metadata-operations.md
@@ -68,18 +68,20 @@ In both layouts, **empty values are skipped by default**: the existing metadata 
 The classic CSV format used by `asset metadata get --format csv` and `asset metadata create-batch --csv-file` is designed for seamless round-trip operations:
 
 ```csv
-ASSET_PATH,NAME,VALUE
-/Root/Folder/Model1.stl,Material,Steel
-/Root/Folder/Model1.stl,Weight,"15.5 kg"
-/Root/Folder/Model2.ipt,Material,Aluminum
-/Root/Folder/Model2.ipt,Supplier,Richardson Electronics
+ASSET_PATH,NAME,VALUE,TYPE
+/Root/Folder/Model1.stl,Material,Steel,text
+/Root/Folder/Model1.stl,Weight,15.5,number
+/Root/Folder/Model2.ipt,Inventory Qty,42,number
+/Root/Folder/Model2.ipt,Supplier Link,https://example.com/,url
+/Root/Folder/Model2.ipt,Exportable,true,boolean
 ```
 
 The CSV format specifications:
-- **Header Row**: Must contain exactly `ASSET_PATH,NAME,VALUE` in that order
-- **ASSET_PATH**: Full path to the asset in Physna (e.g., `/Root/Folder/Model.stl`)
+- **Header Row**: Must contain `ASSET_PATH,NAME,VALUE` in that order, optionally followed by `TYPE`
+- **ASSET_PATH**: Path to the asset in Physna (e.g., `/Root/Folder/Model.stl`). A leading `/Home` — the name Physna shows for the root folder — is treated as the root, so `/Home/NX/part.prt`, `/NX/part.prt`, and `NX/part.prt` all refer to the same asset
 - **NAME**: Name of the metadata field to set
-- **VALUE**: Value to assign to the metadata field. An empty value is skipped by default, or deletes the field from the asset when `--delete-if-empty` is passed
+- **VALUE**: Value to assign to the metadata field. Values are automatically coerced to the field's type (see [Metadata Field Types](#metadata-field-types)). An empty value is skipped by default, or deletes the field from the asset when `--delete-if-empty` is passed
+- **TYPE** *(optional)*: One of `text` (default), `number`, `boolean`, or `url`. This only governs the type used when **registering a new** field; for a field that already exists in Physna, the existing registered type is authoritative and the `TYPE` column is ignored. The column is optional per row — some rows may include it and others may omit it
 - **File Encoding**: Must be UTF-8 encoded
 - **Quoting**: Values containing commas, quotes, or newlines must be enclosed in double quotes
 - **Escaping**: Double quotes within values must be escaped by doubling them (e.g., `"15.5"" diameter"`)
@@ -139,6 +141,43 @@ pcli2 asset metadata create-batch --csv-file "ui-export.csv"
 pcli2 asset metadata create-batch --csv-file "ui-export.csv" --csv-format ui
 ```
 
+## Listing a Tenant's Registered Metadata Fields
+
+Metadata fields are registered per tenant, each with a name and a type. Use
+`tenant metadata list` to see every field currently registered in the active
+tenant:
+
+```bash
+# JSON (default)
+pcli2 tenant metadata list
+
+# CSV, ready to turn into a create-batch file
+pcli2 tenant metadata list --format csv --headers
+```
+
+The CSV output uses the **same column headers as the classic `create-batch`
+input** (`ASSET_PATH,NAME,VALUE,TYPE`), with `NAME` and `TYPE` filled from the
+registry and `ASSET_PATH` and `VALUE` left blank:
+
+```csv
+ASSET_PATH,NAME,VALUE,TYPE
+,Description,,text
+,Exportable,,boolean
+,Inventory Qty,,number
+,Supplier Link,,url
+,Unit Price ($),,number
+```
+
+This makes it easy to build a batch-upload template: save the listing, then for
+each asset fill in `ASSET_PATH` and `VALUE` (replicating the field rows per
+asset). Because values are coerced to each field's registered type, you do not
+need to touch the `TYPE` column for fields that already exist.
+
+```bash
+# Save the field list as a starting template
+pcli2 tenant metadata list --format csv --headers > fields.csv
+```
+
 ## Advanced Metadata Workflow: Export, Modify, Reimport
 
 One of the most powerful features of PCLI2 is the ability to export metadata, modify it externally, and reimport it:
@@ -171,7 +210,7 @@ This workflow enables powerful bulk metadata operations while maintaining the fl
 
 ## Metadata Field Types
 
-PCLI2 supports three metadata field types:
+PCLI2 supports four metadata field types:
 
 1. **Text** (default): String values
    ```bash
@@ -187,6 +226,34 @@ PCLI2 supports three metadata field types:
    ```bash
    pcli2 asset metadata create --path "/Root/Model.stl" --name "Approved" --value "true" --type "boolean"
    ```
+
+4. **URL**: Link values (stored as a string)
+   ```bash
+   pcli2 asset metadata create --path "/Root/Model.stl" --name "Supplier Link" --value "https://example.com/" --type "url"
+   ```
+
+### Automatic type coercion
+
+Every metadata field in a tenant is registered with a type, and the Physna API
+rejects a value whose JSON type does not match. Because a CSV cell is just text,
+PCLI2 **coerces each value to the field's registered type** before sending it —
+so `create-batch` works against typed fields without you having to declare
+anything:
+
+- A `number` field receives `18` (a JSON number) rather than the string `"18"`;
+  `84.50` is sent as `84.5`
+- A `boolean` field accepts `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`
+  (case-insensitive)
+- `text` and `url` fields store the value as a string
+
+If a value cannot be represented as the field's type — for example the text
+`N/A` for a `number` field — that row is a **type conflict** and is reported as
+an error (see [`create-batch` Error Behavior](#create-batch-error-behavior)).
+
+> The registered type always wins. The `--type` flag (single `create`) and the
+> `TYPE` column (batch) only decide the type used when a field is registered for
+> the first time; they cannot change the type of an existing field. To change a
+> field's type, delete and recreate it.
 
 ## Best Practices
 
@@ -209,10 +276,12 @@ Specifically:
 
 - **CSV parsing errors**: always terminate immediately — the input file is expected to be well-formed
 - **Unresolvable asset paths** (asset not found): by default, terminates the batch. Pass `--continue-on-error` to skip the failing asset and continue with the remaining rows
-- **Metadata API failures** (delete/update): always terminate the batch, regardless of `--continue-on-error`. The API layer already retries transient HTTP failures, so a surfaced failure usually indicates a persistent problem (permissions, type conflict, etc.) that is likely to affect subsequent calls as well
-- **Authentication failures**: always terminate with a remediation message directing the user to re-authenticate
+- **Metadata update/delete failures**, including **type conflicts** (a value that cannot be represented as the field's registered type): by default, terminate the batch. Pass `--continue-on-error` to skip the offending asset and continue with the remaining rows
+- **Authentication failures**: always terminate with a remediation message directing the user to re-authenticate, regardless of `--continue-on-error`
 
-**Example — skip unresolvable asset paths:**
+With `--continue-on-error`, skipped assets are reported with a concise warning as they are encountered, and the final summary reports how many assets succeeded and how many failed.
+
+**Example — skip both unresolvable paths and conflicting values:**
 
 ```bash
 pcli2 asset metadata create-batch --csv-file "metadata.csv" --continue-on-error
@@ -257,7 +326,7 @@ pcli2 asset metadata get --path "/Root/Parts/Model.stl" --format csv > metadata_
 
 1. **API Rate Limits**: Extensive operations may be rate-limited by the Physna API
 2. **Processing Time**: Large batch operations can take considerable time
-3. **Metadata Types**: Only supports text, number, and boolean metadata fields
+3. **Metadata Types**: Supports text, number, boolean, and url metadata fields
 4. **Asset Access**: Can only process assets accessible to your authenticated user
 5. **Field Names**: Metadata field names must be unique per asset and follow Physna naming conventions
 

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -563,7 +563,11 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
         };
 
         // Split into fields to delete (empty value, only present when the file
-        // was parsed with --delete-if-empty) and fields to update (non-empty value)
+        // was parsed with --delete-if-empty) and fields to update (non-empty
+        // value). Values are kept as JSON strings here; the actual coercion to
+        // each field's type (registered type wins, else the declared TYPE
+        // column) happens in update_asset_metadata_with_registration, which is
+        // the only layer that knows the tenant's field-type registry.
         let mut fields_to_delete: Vec<String> = Vec::new();
         let mut typed_metadata: HashMap<String, serde_json::Value> = HashMap::new();
 
@@ -575,6 +579,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                 typed_metadata.insert(field_name.clone(), json_value);
             }
         }
+        let declared_types = &entry.types;
 
         // Delete fields with empty values
         if !fields_to_delete.is_empty() {
@@ -599,6 +604,16 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                     failure_count += 1;
                     break;
                 }
+                failure_count += 1;
+
+                if continue_on_error {
+                    warn(format!(
+                        "Skipped '{}' — metadata delete failed: {}",
+                        asset_display, e
+                    ));
+                    continue;
+                }
+
                 report(
                     format!(
                         "Failed to delete metadata fields for asset '{}': {}",
@@ -607,9 +622,9 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                     &[
                         "Verify the metadata field names exist on this asset",
                         "Check that you have sufficient permissions to modify this asset",
+                        "Or re-run with --continue-on-error to skip failing assets",
                     ],
                 );
-                failure_count += 1;
                 if let Some(pb) = progress_bar.as_ref() {
                     pb.finish_and_clear();
                 }
@@ -628,6 +643,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                     &tenant.uuid,
                     &asset.uuid(),
                     &typed_metadata,
+                    Some(declared_types),
                 )
                 .await
             {
@@ -648,6 +664,19 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                     break;
                 }
 
+                failure_count += 1;
+
+                // In continue-on-error mode a per-asset failure (most often a
+                // metadata type conflict) skips just this asset and the run
+                // proceeds, mirroring how unresolved assets are handled.
+                if continue_on_error {
+                    warn(format!(
+                        "Skipped '{}' — metadata update failed: {}",
+                        asset_display, e
+                    ));
+                    continue;
+                }
+
                 let error_str = format!("{}", e);
                 if error_str.contains("must be a") || error_str.contains("Metadata type mismatch") {
                     report(
@@ -656,6 +685,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                             "The metadata field already exists with a different type",
                             "Delete the existing field first if you need to change its type",
                             "Or provide a value that matches the existing field type",
+                            "Or re-run with --continue-on-error to skip conflicting assets",
                         ],
                     );
                 } else {
@@ -669,10 +699,10 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                             "Check that you have sufficient permissions to modify this asset",
                             "Verify your network connectivity",
                             "Confirm the asset hasn't been deleted or modified recently",
+                            "Or re-run with --continue-on-error to skip failing assets",
                         ],
                     );
                 }
-                failure_count += 1;
                 if let Some(pb) = progress_bar.as_ref() {
                     pb.finish_and_clear();
                 }
@@ -766,6 +796,12 @@ pub async fn update_asset_metadata(sub_matches: &ArgMatches) -> Result<(), CliEr
         std::collections::HashMap::new();
     metadata.insert(metadata_name.clone(), json_value);
 
+    // The --type flag declares how the field should be registered if it does
+    // not yet exist. For an existing field the registered type wins.
+    let mut declared_types: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    declared_types.insert(metadata_name.clone(), metadata_type.to_string());
+
     // Resolve asset ID from either UUID parameter or path
     let asset = if let Some(uuid) = asset_uuid_param {
         api.get_asset_by_uuid(&tenant.uuid, uuid).await?
@@ -780,8 +816,13 @@ pub async fn update_asset_metadata(sub_matches: &ArgMatches) -> Result<(), CliEr
     };
 
     // Update the asset's metadata with automatic registration of new keys
-    api.update_asset_metadata_with_registration(&tenant.uuid, &asset.uuid(), &metadata)
-        .await?;
+    api.update_asset_metadata_with_registration(
+        &tenant.uuid,
+        &asset.uuid(),
+        &metadata,
+        Some(&declared_types),
+    )
+    .await?;
 
     // No output on success (per requirements)
 

--- a/src/actions/assets/metadata.rs
+++ b/src/actions/assets/metadata.rs
@@ -164,6 +164,7 @@ pub async fn metadata_inference(sub_matches: &ArgMatches) -> Result<(), CliError
                 &tenant.uuid,
                 &match_result.asset.uuid,
                 &new_metadata_map,
+                None,
             )
             .await?;
 

--- a/src/actions/assets/metadata_batch_csv.rs
+++ b/src/actions/assets/metadata_batch_csv.rs
@@ -18,11 +18,33 @@
 //! classic. Detection can be overridden with the `--csv-format` argument.
 
 use crate::actions::CliActionError;
+use crate::model::normalize_path;
 use std::collections::HashMap;
 use std::io::Read;
 
+/// Normalize an asset path from a batch CSV row to the form the API lookup
+/// expects.
+///
+/// Applies the shared [`normalize_path`] rules — which, per Physna convention,
+/// treat a leading `/Home` (case-insensitive) as the root and collapse
+/// redundant slashes — then drops the single leading slash to match how batch
+/// asset paths are resolved. So `/Home/NX/1.prt`, `/NX/1.prt`, and `NX/1.prt`
+/// all resolve to the same asset (`NX/1.prt`).
+fn normalize_batch_asset_path(raw: &str) -> String {
+    let normalized = normalize_path(raw);
+    normalized
+        .strip_prefix('/')
+        .unwrap_or(&normalized)
+        .to_string()
+}
+
 /// Column-name prefix that marks a metadata column in the UI format.
 pub const METADATA_COLUMN_PREFIX: &str = "metadata:";
+
+/// Field types accepted in the classic layout's optional `TYPE` column. The
+/// registered Physna type is authoritative for existing fields; this declared
+/// type only governs how a *new* field is registered.
+pub const DECLARED_TYPES: [&str; 4] = ["text", "number", "boolean", "url"];
 
 /// How an asset is identified by a batch CSV row.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -74,6 +96,11 @@ pub struct BatchEntry {
     /// "delete this field"; empty values are only produced when the file is
     /// parsed with `delete_if_empty`, otherwise they are skipped.
     pub metadata: HashMap<String, String>,
+    /// Optional caller-declared field type keyed by metadata field name, from
+    /// the classic layout's fourth `TYPE` column. Only used when *registering*
+    /// a new field; for a field that already exists in Physna the registered
+    /// type is authoritative. Absent entries default to `text`.
+    pub types: HashMap<String, String>,
 }
 
 /// Result of parsing a batch CSV file.
@@ -99,7 +126,10 @@ pub fn parse_batch_csv<R: Read>(
     requested: BatchCsvFormat,
     delete_if_empty: bool,
 ) -> Result<ParsedBatch, CliActionError> {
-    let mut csv_reader = csv::Reader::from_reader(reader);
+    // Flexible mode allows rows to have a different field count than the header.
+    // This makes the classic layout's fourth TYPE column optional per row: some
+    // rows may supply it and others may omit it without a length error.
+    let mut csv_reader = csv::ReaderBuilder::new().flexible(true).from_reader(reader);
     let headers = csv_reader.headers()?.clone();
 
     let has_metadata_columns = headers
@@ -152,14 +182,26 @@ impl EntryAccumulator {
         }
     }
 
-    fn add(&mut self, asset: BatchAssetRef, field: String, value: String) {
+    fn add(
+        &mut self,
+        asset: BatchAssetRef,
+        field: String,
+        value: String,
+        declared_type: Option<String>,
+    ) {
         let index = *self.index_by_asset.entry(asset.clone()).or_insert_with(|| {
             self.entries.push(BatchEntry {
                 asset,
                 metadata: HashMap::new(),
+                types: HashMap::new(),
             });
             self.entries.len() - 1
         });
+        if let Some(declared_type) = declared_type {
+            self.entries[index]
+                .types
+                .insert(field.clone(), declared_type);
+        }
         self.entries[index].metadata.insert(field, value);
     }
 }
@@ -172,6 +214,8 @@ fn parse_classic<R: Read>(
 ) -> Result<ParsedBatch, CliActionError> {
     let mut accumulator = EntryAccumulator::new();
     let mut skipped_empty = 0usize;
+    let mut warnings = Vec::new();
+    let mut invalid_types: Vec<String> = Vec::new();
 
     for result in csv_reader.records() {
         let record = result?;
@@ -179,6 +223,8 @@ fn parse_classic<R: Read>(
             let asset_path = record[0].trim();
             let metadata_name = record[1].trim();
             let metadata_value = record[2].trim();
+            // Optional fourth column declares the field type for registration.
+            let declared_type_raw = record.get(3).map(str::trim).unwrap_or("");
 
             // Empty values either mark the field for deletion (with
             // --delete-if-empty) or are skipped, leaving the field untouched.
@@ -187,20 +233,44 @@ fn parse_classic<R: Read>(
                 continue;
             }
 
-            let clean_asset_path = asset_path.strip_prefix('/').unwrap_or(asset_path);
+            // Normalize and validate the declared type. An unrecognized type is
+            // not fatal: it is reported and the field falls back to the default
+            // (text for a new field, or the registered type if it already
+            // exists).
+            let declared_type = if declared_type_raw.is_empty() {
+                None
+            } else {
+                let normalized = declared_type_raw.to_ascii_lowercase();
+                if DECLARED_TYPES.contains(&normalized.as_str()) {
+                    Some(normalized)
+                } else {
+                    invalid_types.push(declared_type_raw.to_string());
+                    None
+                }
+            };
+
             accumulator.add(
-                BatchAssetRef::Path(clean_asset_path.to_string()),
+                BatchAssetRef::Path(normalize_batch_asset_path(asset_path)),
                 metadata_name.to_string(),
                 metadata_value.to_string(),
+                declared_type,
             );
         }
     }
 
-    let mut warnings = Vec::new();
     if skipped_empty > 0 {
         warnings.push(format!(
             "{} row(s) with an empty VALUE were skipped; pass --delete-if-empty to delete those metadata fields instead",
             skipped_empty
+        ));
+    }
+    if !invalid_types.is_empty() {
+        invalid_types.sort();
+        invalid_types.dedup();
+        warnings.push(format!(
+            "Ignoring unrecognized TYPE value(s): {} (expected one of: {}); those fields fall back to their existing or default (text) type",
+            invalid_types.join(", "),
+            DECLARED_TYPES.join(", ")
         ));
     }
 
@@ -296,8 +366,7 @@ fn parse_ui<R: Read>(
             })?;
             BatchAssetRef::Uuid(uuid)
         } else if !path_value.is_empty() {
-            let clean_path = path_value.strip_prefix('/').unwrap_or(path_value);
-            BatchAssetRef::Path(clean_path.to_string())
+            BatchAssetRef::Path(normalize_batch_asset_path(path_value))
         } else {
             return Err(CliActionError::BusinessLogicError(format!(
                 "Line {}: row has neither an 'id' nor a 'path' value to identify the asset",
@@ -311,7 +380,9 @@ fn parse_ui<R: Read>(
             // Empty cells mark the field for deletion (with --delete-if-empty)
             // or are skipped, leaving the existing field value untouched.
             if !value.is_empty() || delete_if_empty {
-                accumulator.add(asset.clone(), field_name.clone(), value.to_string());
+                // The UI layout has no type column; new fields register as text
+                // and existing fields use their registered type.
+                accumulator.add(asset.clone(), field_name.clone(), value.to_string(), None);
                 row_has_values = true;
             }
         }
@@ -365,6 +436,85 @@ mod tests {
         // Leading slash is stripped
         let b = &parsed.entries[1];
         assert_eq!(b.asset, BatchAssetRef::Path("folder/b.stl".to_string()));
+    }
+
+    #[test]
+    fn classic_home_prefix_normalizes_to_root() {
+        // Physna shows the root folder as "Home"; a "/Home/..." path means the
+        // same asset as the equivalent root-relative path. All three spellings
+        // must resolve to the same asset reference.
+        let csv = "ASSET_PATH,NAME,VALUE\n\
+                   /Home/NX/1.prt,Qty,1\n\
+                   /NX/1.prt,Color,Blue\n\
+                   NX/1.prt,Material,Steel\n\
+                   /home/NX/2.prt,Qty,2\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        // First three rows all target NX/1.prt and merge into one entry.
+        assert_eq!(parsed.entries.len(), 2);
+        let a = &parsed.entries[0];
+        assert_eq!(a.asset, BatchAssetRef::Path("NX/1.prt".to_string()));
+        assert_eq!(a.metadata.len(), 3);
+        // Case-insensitive: "/home/..." also normalizes.
+        let b = &parsed.entries[1];
+        assert_eq!(b.asset, BatchAssetRef::Path("NX/2.prt".to_string()));
+    }
+
+    #[test]
+    fn ui_home_prefix_normalizes_to_root() {
+        let csv = "path,id,metadata:Material\n\
+                   /Home/NX/1.prt,,Steel\n\
+                   NX/1.prt,,Aluminum\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        // Both rows target NX/1.prt; the second row wins on the field conflict.
+        assert_eq!(parsed.entries.len(), 1);
+        assert_eq!(
+            parsed.entries[0].asset,
+            BatchAssetRef::Path("NX/1.prt".to_string())
+        );
+        assert_eq!(
+            parsed.entries[0].metadata.get("Material").unwrap(),
+            "Aluminum"
+        );
+    }
+
+    #[test]
+    fn classic_reads_optional_type_column() {
+        let csv = "ASSET_PATH,NAME,VALUE,TYPE\n\
+                   NX/1.prt,Inventory Qty,18,number\n\
+                   NX/1.prt,Supplier Link,https://x.com/,url\n\
+                   NX/1.prt,Description,A part,\n\
+                   NX/1.prt,Material,Steel\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        assert_eq!(parsed.format, BatchCsvFormat::Classic);
+        let entry = &parsed.entries[0];
+        assert_eq!(entry.metadata.get("Inventory Qty").unwrap(), "18");
+        assert_eq!(entry.types.get("Inventory Qty").unwrap(), "number");
+        assert_eq!(entry.types.get("Supplier Link").unwrap(), "url");
+        // Empty TYPE cell and a missing TYPE column both mean "no declared type".
+        assert!(!entry.types.contains_key("Description"));
+        assert!(!entry.types.contains_key("Material"));
+    }
+
+    #[test]
+    fn classic_type_column_is_case_insensitive() {
+        let csv = "ASSET_PATH,NAME,VALUE,TYPE\n\
+                   NX/1.prt,Qty,18,NUMBER\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        assert_eq!(parsed.entries[0].types.get("Qty").unwrap(), "number");
+    }
+
+    #[test]
+    fn classic_unknown_type_is_warned_and_ignored() {
+        let csv = "ASSET_PATH,NAME,VALUE,TYPE\n\
+                   NX/1.prt,Qty,18,integer\n";
+        let parsed = parse(csv, BatchCsvFormat::Auto).unwrap();
+        // Value is still captured; only the bad type declaration is dropped.
+        assert_eq!(parsed.entries[0].metadata.get("Qty").unwrap(), "18");
+        assert!(!parsed.entries[0].types.contains_key("Qty"));
+        assert!(parsed
+            .warnings
+            .iter()
+            .any(|w| w.contains("unrecognized TYPE") && w.contains("integer")));
     }
 
     #[test]

--- a/src/actions/tenants.rs
+++ b/src/actions/tenants.rs
@@ -529,3 +529,47 @@ pub async fn get_tenant_state_counts(sub_matches: &ArgMatches) -> Result<(), Cli
 
     Ok(())
 }
+
+/// List all metadata fields registered in the tenant, with their data types.
+///
+/// This backs the `tenant metadata list` command. The CSV output deliberately
+/// mirrors the classic `asset metadata create-batch` input header
+/// (`ASSET_PATH,NAME,VALUE,TYPE`) so the listing can be turned into a
+/// batch-upload template: NAME and TYPE come from the registry, ASSET_PATH and
+/// VALUE are left empty for the user to fill.
+pub async fn list_tenant_metadata_fields(
+    sub_matches: &ArgMatches,
+) -> Result<(), crate::error::CliError> {
+    trace!("Executing tenant metadata list command...");
+
+    // Build format options directly (mirroring `tenant state`) rather than via
+    // FormatParams, which requires a --with-metadata flag this command does not
+    // define. Metadata fields have no per-record metadata of their own.
+    let format_str = sub_matches
+        .get_one::<String>(crate::commands::params::PARAMETER_FORMAT)
+        .cloned()
+        .unwrap_or_else(|| "json".to_string());
+    let with_headers = sub_matches.get_flag(crate::commands::params::PARAMETER_HEADERS);
+    let pretty = sub_matches.get_flag(crate::commands::params::PARAMETER_PRETTY);
+
+    let format_options = crate::format::OutputFormatOptions {
+        with_metadata: false,
+        with_headers,
+        pretty,
+    };
+    let format = crate::format::OutputFormat::from_string_with_options(&format_str, format_options)
+        .map_err(crate::error::CliError::FormattingError)?;
+
+    let configuration = Configuration::load_or_create_default()?;
+    let mut api = PhysnaApiClient::try_default()?;
+    let tenant = crate::param_utils::get_tenant(&mut api, sub_matches, &configuration).await?;
+
+    let fields = api
+        .get_metadata_fields(&tenant.uuid.to_string())
+        .await
+        .map_err(crate::error::CliError::PhysnaExtendedApiError)?;
+
+    println!("{}", fields.format(format)?);
+
+    Ok(())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -210,6 +210,27 @@ pub async fn execute_command(commands: clap::ArgMatches) -> Result<(), CliError>
                     pcli2::actions::tenants::get_tenant_state_counts(sub_matches).await?;
                     Ok(())
                 }
+                Some((COMMAND_METADATA, sub_matches)) => {
+                    trace!("Command: {} {}", COMMAND_TENANT, COMMAND_METADATA);
+
+                    match sub_matches.subcommand() {
+                        Some((COMMAND_LIST, sub_matches)) => {
+                            trace!(
+                                "Command: {} {} {}",
+                                COMMAND_TENANT,
+                                COMMAND_METADATA,
+                                COMMAND_LIST
+                            );
+
+                            pcli2::actions::tenants::list_tenant_metadata_fields(sub_matches)
+                                .await?;
+                            Ok(())
+                        }
+                        _ => Err(CliError::UnsupportedSubcommand(extract_subcommand_name(
+                            sub_matches,
+                        ))),
+                    }
+                }
                 _ => Err(CliError::UnsupportedSubcommand(extract_subcommand_name(
                     sub_matches,
                 ))),

--- a/src/commands/metadata.rs
+++ b/src/commands/metadata.rs
@@ -60,9 +60,9 @@ pub fn metadata_command() -> Command {
                         .long("type")
                         .num_args(1)
                         .required(false)
-                        .value_parser(["text", "number", "boolean"])
+                        .value_parser(["text", "number", "boolean", "url"])
                         .default_value("text")
-                        .help("Metadata field type (text, number, boolean) - default: text")
+                        .help("Metadata field type (text, number, boolean, url) - default: text")
                 )
                 .group(
                     ArgGroup::new("asset_identifier")
@@ -107,14 +107,20 @@ pub fn metadata_command() -> Command {
                     CLASSIC (vertical) format — one row per asset+field combination:\n\
                     - ASSET_PATH: The full path of the asset in Physna\n\
                     - NAME: The name of the metadata field to set\n\
-                    - VALUE: The value to set for the metadata field\n\n\
+                    - VALUE: The value to set for the metadata field\n\
+                    - TYPE: Optional field type (text, number, boolean, url); \
+                    default text. Values are automatically coerced to each \
+                    field's type — a number-typed field receives 18, not \"18\". \
+                    For a field that already exists in Physna its registered type \
+                    is authoritative and TYPE only applies when registering a new \
+                    field.\n\n\
                     If an asset has multiple metadata fields to update, include multiple rows \n\
                     with the same ASSET_PATH but different NAME and VALUE combinations.\n\n\
                     Example:\n\
-                    ASSET_PATH,NAME,VALUE\n\
-                    folder/subfolder/asset1.stl,Material,Steel\n\
-                    folder/subfolder/asset1.stl,Weight,\"15.5 kg\"\n\
-                    folder/subfolder/asset2.ipt,Material,Aluminum\n\n\
+                    ASSET_PATH,NAME,VALUE,TYPE\n\
+                    folder/subfolder/asset1.stl,Material,Steel,text\n\
+                    folder/subfolder/asset1.stl,Inventory Qty,18,number\n\
+                    folder/subfolder/asset2.ipt,Exportable,true,boolean\n\n\
                     UI (horizontal) format — one row per asset, as exported by the Physna \
                     web UI's bulk metadata upload:\n\
                     - path: The full path of the asset in Physna\n\
@@ -136,12 +142,13 @@ pub fn metadata_command() -> Command {
                     - Values containing commas, quotes, or newlines must be enclosed in double quotes\n\n\
                     The command groups metadata by asset and updates all metadata \
                     for each asset in a single API call.\n\n\
-                    By default, any error (such as an asset that cannot be resolved \
-                    or a failed metadata API call) terminates the batch operation. \
-                    Pass --continue-on-error to skip assets that cannot be resolved \
-                    and continue with the remaining rows. Metadata API errors always \
-                    terminate execution regardless of this flag, because the API already \
-                    retries transient failures internally."
+                    By default, any error (such as an asset that cannot be resolved, \
+                    a metadata type conflict, or a failed metadata API call) terminates \
+                    the batch operation. Pass --continue-on-error to skip the offending \
+                    asset — whether it cannot be resolved or its metadata update fails — \
+                    and continue with the remaining rows. A type conflict occurs when a \
+                    value cannot be represented as the field's registered type (for \
+                    example the text \"N/A\" for a number field)."
                 )
                 .arg(tenant_parameter())
                 .arg(

--- a/src/commands/tenant.rs
+++ b/src/commands/tenant.rs
@@ -4,7 +4,8 @@
 
 use crate::commands::params::{
     format_parameter, format_pretty_parameter, format_with_headers_parameter,
-    tenant_name_parameter, COMMAND_CLEAR, COMMAND_GET, COMMAND_LIST, COMMAND_TENANT, COMMAND_USE,
+    tenant_name_parameter, tenant_parameter, COMMAND_CLEAR, COMMAND_GET, COMMAND_LIST,
+    COMMAND_METADATA, COMMAND_TENANT, COMMAND_USE,
 };
 use clap::Command;
 
@@ -59,5 +60,31 @@ pub fn tenant_command() -> Command {
             Command::new(COMMAND_CLEAR)
                 .about("Clear the active tenant")
                 .visible_alias("unset"),
+        )
+        .subcommand(
+            Command::new(COMMAND_METADATA)
+                .about("Inspect the tenant's metadata-field registry")
+                .subcommand_required(true)
+                .subcommand(
+                    Command::new(COMMAND_LIST)
+                        .about("List all metadata fields registered in the tenant with their types")
+                        .visible_alias("ls")
+                        .long_about(
+                            "List every metadata field registered in the tenant along with its \
+                            data type (text, number, boolean, url, ...).\n\n\
+                            The CSV output uses the same column headers as the classic \
+                            'asset metadata create-batch' input (ASSET_PATH,NAME,VALUE,TYPE), \
+                            with the NAME and TYPE columns filled from the registry and the \
+                            ASSET_PATH and VALUE columns left empty. This makes it easy to save \
+                            the listing and turn it into a batch-upload file: replicate each row \
+                            per asset, then fill in ASSET_PATH and VALUE.\n\n\
+                            Example:\n\
+                            pcli2 tenant metadata list --format csv --headers > fields.csv",
+                        )
+                        .arg(tenant_parameter())
+                        .arg(format_parameter().value_parser(["json", "csv", "tree"]))
+                        .arg(format_pretty_parameter())
+                        .arg(format_with_headers_parameter()),
+                ),
         )
 }

--- a/src/format/impls/metadata_field.rs
+++ b/src/format/impls/metadata_field.rs
@@ -1,0 +1,158 @@
+//! Formatting implementations for the tenant metadata-field registry.
+//!
+//! `tenant metadata list` reports every metadata field registered in the tenant
+//! together with its data type. The CSV layout deliberately mirrors the classic
+//! `asset metadata create-batch` input (`ASSET_PATH,NAME,VALUE,TYPE`) so the
+//! output can be turned into a batch-upload file: the NAME and TYPE columns are
+//! filled from the registry and the ASSET_PATH and VALUE columns are left empty
+//! for the user to populate.
+
+use crate::format::{CsvRecordProducer, FormattingError, OutputFormat, OutputFormatter};
+use crate::model::{MetadataField, MetadataFieldListResponse};
+use csv::Writer;
+
+impl CsvRecordProducer for MetadataFieldListResponse {
+    fn csv_header() -> Vec<String> {
+        vec![
+            "ASSET_PATH".to_string(),
+            "NAME".to_string(),
+            "VALUE".to_string(),
+            "TYPE".to_string(),
+        ]
+    }
+
+    fn as_csv_records(&self) -> Vec<Vec<String>> {
+        self.metadata_fields
+            .iter()
+            .map(|field| {
+                vec![
+                    // ASSET_PATH and VALUE are left blank so the output is a
+                    // ready-to-fill create-batch template.
+                    String::new(),
+                    field.name.clone(),
+                    String::new(),
+                    field.field_type.clone(),
+                ]
+            })
+            .collect()
+    }
+}
+
+impl OutputFormatter for MetadataFieldListResponse {
+    type Item = MetadataFieldListResponse;
+
+    fn format(&self, format: OutputFormat) -> Result<String, FormattingError> {
+        match format {
+            OutputFormat::Json(options) => {
+                // Emit a flat array of {name, type}, sorted by name, rather than
+                // the paginated envelope the API returns.
+                let mut fields: Vec<MetadataField> = self.metadata_fields.clone();
+                fields.sort_by(|a, b| a.name.cmp(&b.name));
+                let json = if options.pretty {
+                    serde_json::to_string_pretty(&fields)
+                } else {
+                    serde_json::to_string(&fields)
+                };
+                json.map_err(|e| FormattingError::FormatFailure { cause: Box::new(e) })
+            }
+            OutputFormat::Csv(options) => {
+                let mut wtr = Writer::from_writer(vec![]);
+                if options.with_headers {
+                    wtr.write_record(Self::csv_header())?;
+                }
+
+                // Sort by the NAME column (index 1) for stable, readable output.
+                let mut records = self.as_csv_records();
+                records.sort_by(|a, b| a[1].cmp(&b[1]));
+
+                for record in records {
+                    wtr.write_record(&record).map_err(|e| {
+                        FormattingError::CsvWriterError(format!(
+                            "Failed to write CSV record: {}",
+                            e
+                        ))
+                    })?;
+                }
+                let data = wtr.into_inner().map_err(|e| {
+                    FormattingError::CsvWriterError(format!("Failed to finalize CSV: {}", e))
+                })?;
+                String::from_utf8(data).map_err(FormattingError::Utf8Error)
+            }
+            OutputFormat::Tree(_) => {
+                let mut fields: Vec<&MetadataField> = self.metadata_fields.iter().collect();
+                fields.sort_by(|a, b| a.name.cmp(&b.name));
+                let mut output = String::new();
+                for field in fields {
+                    output.push_str(&format!("{} ({})\n", field.name, field.field_type));
+                }
+                Ok(output)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format::OutputFormatOptions;
+
+    fn sample() -> MetadataFieldListResponse {
+        MetadataFieldListResponse {
+            metadata_fields: vec![
+                MetadataField {
+                    name: "Unit Price ($)".to_string(),
+                    field_type: "number".to_string(),
+                },
+                MetadataField {
+                    name: "Description".to_string(),
+                    field_type: "text".to_string(),
+                },
+                MetadataField {
+                    name: "Supplier Link".to_string(),
+                    field_type: "url".to_string(),
+                },
+            ],
+            page_data: None,
+        }
+    }
+
+    #[test]
+    fn csv_matches_create_batch_header_and_is_sorted() {
+        let options = OutputFormatOptions {
+            with_metadata: false,
+            with_headers: true,
+            pretty: false,
+        };
+        let out = sample().format(OutputFormat::Csv(options)).unwrap();
+        let expected = "ASSET_PATH,NAME,VALUE,TYPE\n\
+                        ,Description,,text\n\
+                        ,Supplier Link,,url\n\
+                        ,Unit Price ($),,number\n";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn csv_can_omit_headers() {
+        let options = OutputFormatOptions {
+            with_metadata: false,
+            with_headers: false,
+            pretty: false,
+        };
+        let out = sample().format(OutputFormat::Csv(options)).unwrap();
+        assert!(!out.contains("ASSET_PATH"));
+        assert!(out.starts_with(",Description,,text"));
+    }
+
+    #[test]
+    fn json_is_flat_sorted_array_of_name_and_type() {
+        let options = OutputFormatOptions::default();
+        let out = sample().format(OutputFormat::Json(options)).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0]["name"], "Description");
+        assert_eq!(arr[0]["type"], "text");
+        assert_eq!(arr[2]["name"], "Unit Price ($)");
+        assert_eq!(arr[2]["type"], "number");
+    }
+}

--- a/src/format/impls/mod.rs
+++ b/src/format/impls/mod.rs
@@ -8,6 +8,7 @@
 //! - `tenant`: Tenant and TenantList formatting
 //! - `asset`: Asset, AssetList, and thumbnail variants formatting
 //! - `metadata`: AssetMetadata formatting
+//! - `metadata_field`: tenant metadata-field registry (`tenant metadata list`)
 //! - `match_ops`: Search and match response formatting (part search, geometric search, etc.)
 //! - `dependencies`: Asset dependency and assembly tree formatting
 //! - `state`: Asset state counts formatting
@@ -19,5 +20,6 @@ mod folder;
 mod health;
 mod match_ops;
 mod metadata;
+mod metadata_field;
 mod state;
 mod tenant;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -159,10 +159,11 @@ pub fn convert_single_metadata_to_json_value(
             serde_json::Value::Bool(bool_val)
         }
         _ => {
-            // Text (the default): always serialize as a JSON string, even when the
-            // value looks numeric or boolean. The `--type` flag is authoritative, so
-            // `--type text --value 100` must produce the string "100" rather than the
-            // number 100 (which the API rejects for string-typed metadata fields).
+            // Text (the default) and other string-backed types such as `url`:
+            // always serialize as a JSON string, even when the value looks
+            // numeric or boolean. The `--type` flag is authoritative, so
+            // `--type text --value 100` must produce the string "100" rather than
+            // the number 100 (which the API rejects for string-typed fields).
             serde_json::Value::String(value.to_string())
         }
     }
@@ -228,6 +229,14 @@ mod tests {
             value,
             Value::Number(serde_json::Number::from_f64(2.5).unwrap())
         );
+    }
+
+    #[test]
+    fn url_type_serializes_as_string() {
+        // A url-typed field stores a plain JSON string.
+        let value =
+            convert_single_metadata_to_json_value("Supplier Link", "https://example.com/", "url");
+        assert_eq!(value, Value::String("https://example.com/".to_string()));
     }
 
     #[test]

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -1907,11 +1907,11 @@ impl PhysnaApiClient {
         tenant_uuid: &Uuid,
         asset_uuid: &Uuid,
         metadata: &std::collections::HashMap<String, serde_json::Value>,
+        declared_types: Option<&std::collections::HashMap<String, String>>,
     ) -> Result<(), ApiError> {
         // Get existing metadata fields for the tenant
         let existing_fields_response = self.get_metadata_fields(&tenant_uuid.to_string()).await;
 
-        let mut existing_field_names = std::collections::HashSet::new();
         let mut field_type_map: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
 
@@ -1925,7 +1925,6 @@ impl PhysnaApiClient {
                     "Found metadata field: '{}' with type: '{}'",
                     field.name, field.field_type
                 );
-                existing_field_names.insert(field.name.clone());
                 field_type_map.insert(field.name, field.field_type);
             }
         } else {
@@ -1935,54 +1934,79 @@ impl PhysnaApiClient {
             );
         }
 
-        // Check each metadata key for type compatibility before updating
-        for (key, value) in metadata.iter() {
-            debug!(
-                "Checking metadata key '{}' with value type '{}'",
-                key,
-                Self::infer_json_value_type(value)
-            );
-            if existing_field_names.contains(key) {
-                // Field exists - check for type mismatch
-                if let Some(expected_type) = field_type_map.get(key) {
-                    let provided_type = Self::infer_json_value_type(value);
+        // Build the outgoing payload, coercing every value to the type the field
+        // is (or will be) registered with. The registered type is authoritative:
+        // a string "18" is sent as the JSON number 18 for a number-typed field, a
+        // URL string is kept as a string for a url-typed field, and so on. A
+        // value that cannot be represented as the field's type is a genuine
+        // conflict and returns MetadataTypeMismatch.
+        let mut coerced: std::collections::HashMap<String, serde_json::Value> =
+            std::collections::HashMap::with_capacity(metadata.len());
 
-                    // Check if types are incompatible
-                    if !Self::is_type_compatible(expected_type, &provided_type) {
+        for (key, value) in metadata.iter() {
+            if let Some(expected_type) = field_type_map.get(key) {
+                // Field already exists: coerce the value to its registered type.
+                match Self::coerce_value_to_type(value, expected_type) {
+                    Some(coerced_value) => {
                         debug!(
-                            "Type mismatch detected: field '{}' expected '{}' but got '{}'",
-                            key, expected_type, provided_type
+                            "Coerced metadata field '{}' to registered type '{}'",
+                            key, expected_type
                         );
+                        coerced.insert(key.clone(), coerced_value);
+                    }
+                    None => {
                         return Err(ApiError::MetadataTypeMismatch {
                             field_name: key.clone(),
                             expected_type: expected_type.clone(),
-                            provided_type,
+                            provided_type: Self::infer_json_value_type(value),
                         });
                     }
                 }
             } else {
-                debug!(
-                    "Metadata field '{}' not found in existing fields, will attempt to register",
-                    key
-                );
-                // Register the new metadata field (default to text type)
-                let field_result = self
-                    .create_metadata_field(&tenant_uuid.to_string(), key, Some("text"))
-                    .await;
+                // New field: register it with the caller-declared type when
+                // provided, otherwise infer it from the value (defaulting to
+                // text). A declared type must still be able to hold the value.
+                let register_type = declared_types
+                    .and_then(|m| m.get(key))
+                    .map(|s| s.as_str())
+                    .unwrap_or_else(|| match Self::infer_json_value_type(value).as_str() {
+                        "number" => "number",
+                        "boolean" => "boolean",
+                        _ => "text",
+                    });
 
-                // Log the result of field creation
-                match field_result {
+                let coerced_value = match Self::coerce_value_to_type(value, register_type) {
+                    Some(v) => v,
+                    None => {
+                        return Err(ApiError::MetadataTypeMismatch {
+                            field_name: key.clone(),
+                            expected_type: register_type.to_string(),
+                            provided_type: Self::infer_json_value_type(value),
+                        });
+                    }
+                };
+
+                debug!(
+                    "Metadata field '{}' not found; registering as type '{}'",
+                    key, register_type
+                );
+                match self
+                    .create_metadata_field(&tenant_uuid.to_string(), key, Some(register_type))
+                    .await
+                {
                     Ok(_) => debug!("Successfully registered new metadata field: {}", key),
                     Err(e) => {
                         debug!("Failed to register metadata field '{}': {}", key, e);
-                        // Continue anyway, as the API might allow setting values for unregistered keys
+                        // Continue anyway, as the API might allow setting values
+                        // for unregistered keys.
                     }
                 }
+                coerced.insert(key.clone(), coerced_value);
             }
         }
 
-        // Now update the asset metadata
-        self.update_asset_metadata(tenant_uuid, asset_uuid, metadata)
+        // Now update the asset metadata with the coerced values
+        self.update_asset_metadata(tenant_uuid, asset_uuid, &coerced)
             .await
     }
 
@@ -2004,22 +2028,65 @@ impl PhysnaApiClient {
         }
     }
 
-    /// Check if two metadata types are compatible
+    /// Coerce a JSON value so it matches a metadata field's declared type, or
+    /// return `None` when the value cannot be represented as that type.
     ///
-    /// This function determines if a provided type can be assigned to a field with an expected type.
-    /// For now, we use strict type matching, but this could be extended to allow compatible conversions
-    /// (e.g., number to text).
+    /// The field's type (as registered in Physna) is authoritative, so this is
+    /// how a batch CSV — which carries only string values — gets its values
+    /// turned into the JSON scalars the API requires:
     ///
-    /// # Arguments
-    /// * `expected_type` - The type of the existing metadata field
-    /// * `provided_type` - The type of the value being assigned
+    /// - `number`: an existing JSON number is kept; a string that parses as an
+    ///   integer or float becomes a JSON number; anything else is a conflict.
+    /// - `boolean`: an existing JSON bool is kept; `true/false/1/0/yes/no/on/off`
+    ///   (case-insensitive) parse to a bool; anything else is a conflict.
+    /// - `text`, `url`, and any other string-backed type: the value is stored as
+    ///   a JSON string, stringifying numbers and bools as needed. This is why a
+    ///   URL string is accepted by a `url`-typed field even though the JSON type
+    ///   is "string".
     ///
-    /// # Returns
-    /// * `bool` - true if the types are compatible, false otherwise
-    fn is_type_compatible(expected_type: &str, provided_type: &str) -> bool {
-        // For now, use strict type matching
-        // Future enhancement: allow number -> text conversion since numbers can be stringified
-        expected_type == provided_type
+    /// `Null` is never produced here; empty values are handled as deletes before
+    /// reaching this function.
+    fn coerce_value_to_type(
+        value: &serde_json::Value,
+        field_type: &str,
+    ) -> Option<serde_json::Value> {
+        use serde_json::Value;
+        match field_type {
+            "number" => match value {
+                Value::Number(_) => Some(value.clone()),
+                Value::String(s) => {
+                    let s = s.trim();
+                    if let Ok(i) = s.parse::<i64>() {
+                        Some(Value::Number(i.into()))
+                    } else if let Ok(f) = s.parse::<f64>() {
+                        if f.fract() == 0.0 && f.abs() < i64::MAX as f64 {
+                            Some(Value::Number((f as i64).into()))
+                        } else {
+                            serde_json::Number::from_f64(f).map(Value::Number)
+                        }
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            },
+            "boolean" => match value {
+                Value::Bool(_) => Some(value.clone()),
+                Value::String(s) => match s.trim().to_ascii_lowercase().as_str() {
+                    "true" | "1" | "yes" | "on" => Some(Value::Bool(true)),
+                    "false" | "0" | "no" | "off" => Some(Value::Bool(false)),
+                    _ => None,
+                },
+                _ => None,
+            },
+            // text, url, and anything else are stored as JSON strings.
+            _ => match value {
+                Value::String(_) => Some(value.clone()),
+                Value::Number(n) => Some(Value::String(n.to_string())),
+                Value::Bool(b) => Some(Value::String(b.to_string())),
+                _ => None,
+            },
+        }
     }
 
     /// Delete specific metadata fields from an asset
@@ -5038,24 +5105,67 @@ mod tests {
     }
 
     #[test]
-    fn test_is_type_compatible_same_types() {
-        assert!(PhysnaApiClient::is_type_compatible("text", "text"));
-        assert!(PhysnaApiClient::is_type_compatible("number", "number"));
-        assert!(PhysnaApiClient::is_type_compatible("boolean", "boolean"));
+    fn test_coerce_string_to_number() {
+        // A batch CSV carries "18" as a string; a number-typed field must
+        // receive the JSON number 18, not the string "18".
+        let v = serde_json::Value::String("18".to_string());
+        assert_eq!(
+            PhysnaApiClient::coerce_value_to_type(&v, "number"),
+            Some(serde_json::Value::Number(18.into()))
+        );
+
+        let v = serde_json::Value::String("84.50".to_string());
+        assert_eq!(
+            PhysnaApiClient::coerce_value_to_type(&v, "number"),
+            serde_json::Number::from_f64(84.5).map(serde_json::Value::Number)
+        );
     }
 
     #[test]
-    fn test_is_type_compatible_different_types() {
-        assert!(!PhysnaApiClient::is_type_compatible("text", "number"));
-        assert!(!PhysnaApiClient::is_type_compatible("number", "boolean"));
-        assert!(!PhysnaApiClient::is_type_compatible("text", "boolean"));
+    fn test_coerce_non_numeric_string_to_number_is_conflict() {
+        let v = serde_json::Value::String("N/A".to_string());
+        assert_eq!(PhysnaApiClient::coerce_value_to_type(&v, "number"), None);
     }
 
     #[test]
-    fn test_is_type_compatible_null_and_array() {
-        assert!(!PhysnaApiClient::is_type_compatible("text", "null"));
-        assert!(!PhysnaApiClient::is_type_compatible("text", "array"));
-        assert!(!PhysnaApiClient::is_type_compatible("text", "object"));
+    fn test_coerce_string_to_boolean() {
+        for (input, expected) in [
+            ("true", true),
+            ("FALSE", false),
+            ("yes", true),
+            ("off", false),
+        ] {
+            let v = serde_json::Value::String(input.to_string());
+            assert_eq!(
+                PhysnaApiClient::coerce_value_to_type(&v, "boolean"),
+                Some(serde_json::Value::Bool(expected)),
+                "input: {input}"
+            );
+        }
+
+        let v = serde_json::Value::String("maybe".to_string());
+        assert_eq!(PhysnaApiClient::coerce_value_to_type(&v, "boolean"), None);
+    }
+
+    #[test]
+    fn test_coerce_url_and_text_keep_string() {
+        // A url-typed field stores a plain JSON string; the value must not be
+        // rejected just because its declared type is "url" rather than "text".
+        let v = serde_json::Value::String("https://example.com/".to_string());
+        assert_eq!(
+            PhysnaApiClient::coerce_value_to_type(&v, "url"),
+            Some(v.clone())
+        );
+        assert_eq!(PhysnaApiClient::coerce_value_to_type(&v, "text"), Some(v));
+    }
+
+    #[test]
+    fn test_coerce_number_to_text_stringifies() {
+        let v = serde_json::Value::Number(18.into());
+        assert_eq!(
+            PhysnaApiClient::coerce_value_to_type(&v, "text"),
+            Some(serde_json::Value::String("18".to_string()))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Release **v1.11.0**.

## Highlights
- **Fix:** `asset metadata create-batch` now coerces CSV values to each field's registered type, so `number`/`boolean`/`url` fields populate without error (previously rejected as type mismatches).
- **New:** `tenant metadata list` — lists the tenant's registered metadata fields with their types, in a CSV layout that doubles as a create-batch template.
- **New:** optional `TYPE` column for the classic batch CSV; `url` added to `asset metadata create --type`.
- **Fix:** leading `/Home` in a batch `ASSET_PATH` resolves to the root.
- **Change:** `--continue-on-error` now also skips metadata update/delete failures (e.g. type conflicts), not just unresolved paths.

See [CHANGELOG.md](CHANGELOG.md) for the full 1.11.0 entry.

Verified: 114 lib tests pass, `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean, and the changes were live-verified against a real tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)