### PR TITLE
feat(text-match): raise default limit to 1000 and warn on truncated results

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ pcli2 asset dependency-diff  # Diff the dependency trees of two assets
 pcli2 asset geometric-match  # Find geometrically similar assets
 pcli2 asset part-match       # Find part matches for an asset
 pcli2 asset visual-match     # Find visually similar assets (--limit N, default 100; --threshold N size filter, default 80)
-pcli2 asset text-match       # Find assets using text search
+pcli2 asset text-match       # Find assets using text search (--limit N, default 1000; warns on stderr when more matches exist)
 pcli2 asset reprocess        # Reprocess an asset to refresh its analysis
 pcli2 asset thumbnail        # Download asset thumbnail
 pcli2 asset metadata         # Manage asset metadata

--- a/src/actions/assets/match_ops.rs
+++ b/src/actions/assets/match_ops.rs
@@ -2266,10 +2266,19 @@ pub async fn text_match(sub_matches: &ArgMatches) -> Result<(), CliError> {
     let tenant_name = ctx.tenant().name.clone();
 
     // Perform text search
-    let mut search_results = ctx
+    let (mut search_results, truncated) = ctx
         .api()
         .text_search(&tenant_uuid, &search_query, limit)
         .await?;
+
+    // Warn on stderr (so piped stdout data is unaffected) when the limit
+    // truncated the result set.
+    if truncated {
+        eprintln!(
+            "⚠️  Result limit reached: showing the first {} matching assets; increase --limit to retrieve more",
+            search_results.matches.len()
+        );
+    }
 
     // Load configuration to get the UI base URL
     let configuration =

--- a/src/commands/assets.rs
+++ b/src/commands/assets.rs
@@ -257,7 +257,10 @@ pub fn asset_command() -> Command {
                     .action(clap::ArgAction::SetTrue)
                     .help("Perform fuzzy search instead of exact search (default: false, which means exact search with quoted text)"),
             )
-            .arg(limit_parameter())
+            // Text search ranks name matches above metadata-only matches, so a
+            // small limit silently drops the latter; default high and warn on
+            // truncation instead (see text_match in actions/assets/match_ops.rs).
+            .arg(limit_parameter().default_value("1000"))
             .arg(format_with_headers_parameter())
             .arg(format_with_metadata_parameter())  // Add metadata flag to be consistent with other match commands
             .arg(format_pretty_parameter())

--- a/src/commands/params.rs
+++ b/src/commands/params.rs
@@ -193,6 +193,8 @@ pub fn format_with_metadata_parameter() -> Arg {
 ///
 /// Used by the visual-match commands to cap the number of returned results,
 /// since visual search returns every asset ranked by visual similarity.
+/// The text-match command overrides the default to 1000 so lower-ranked
+/// metadata-only matches are not silently dropped.
 pub fn limit_parameter() -> Arg {
     Arg::new(PARAMETER_LIMIT)
         .long(PARAMETER_LIMIT)

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -3166,14 +3166,16 @@ impl PhysnaApiClient {
     /// * `limit` - Maximum number of matches to return
     ///
     /// # Returns
-    /// * `Ok(TextSearchResponse)` - The search results with text-matched assets
+    /// * `Ok((TextSearchResponse, bool))` - The search results with
+    ///   text-matched assets, plus a flag that is `true` when `limit` cut the
+    ///   result set short (more matches were available from the endpoint)
     ///
     pub async fn text_search(
         &mut self,
         tenant_uuid: &Uuid,
         text_query: &str,
         limit: usize,
-    ) -> Result<crate::model::TextSearchResponse, ApiError> {
+    ) -> Result<(crate::model::TextSearchResponse, bool), ApiError> {
         debug!(
             "Starting text search for tenant_uuid: {}, query: {}, limit: {}",
             tenant_uuid, text_query, limit
@@ -3193,6 +3195,16 @@ impl PhysnaApiClient {
         // Track the maximum last_page value seen to prevent infinite loops.
         let mut max_last_page_seen = 0;
         let max_pages_limit = 1000; // Hard limit to prevent excessive API calls
+
+        // Total number of matches reported by the endpoint. Note: the endpoint
+        // may report a larger total than it actually serves across pages, so
+        // this is informational only — truncation is detected from pagination
+        // state, not from this figure.
+        let mut total_available: Option<usize> = None;
+
+        // Set when pagination stops early because `limit` was reached while
+        // more pages remained.
+        let mut truncated = false;
 
         loop {
             if page > max_pages_limit {
@@ -3230,6 +3242,8 @@ impl PhysnaApiClient {
                             max_last_page_seen = page_data.last_page;
                         }
 
+                        total_available = Some(page_data.total);
+
                         all_matches.extend(response.matches);
 
                         // Stop once we have enough results, reach the last page,
@@ -3239,6 +3253,8 @@ impl PhysnaApiClient {
                             || page_data.current_page >= page_data.last_page
                             || page_data.current_page < page
                         {
+                            truncated = all_matches.len() >= limit
+                                && page_data.current_page < page_data.last_page;
                             break;
                         }
 
@@ -3248,8 +3264,11 @@ impl PhysnaApiClient {
                         // the requested limit.
                         debug!("No pagination data in text search response, returning single page");
                         let mut response = response;
+                        total_available = Some(response.matches.len());
+                        truncated = response.matches.len() > limit;
                         response.matches.truncate(limit);
-                        return Ok(response);
+                        all_matches = response.matches;
+                        break;
                     }
                 }
                 Err(e) => {
@@ -3260,19 +3279,35 @@ impl PhysnaApiClient {
         }
 
         // The last page may overshoot the requested limit; cap it here.
+        truncated = truncated || all_matches.len() > limit;
         all_matches.truncate(limit);
 
         debug!(
-            "Text search completed for query: '{}' with {} total matches",
+            "Text search completed for query: '{}' with {} total matches (truncated: {})",
             text_query,
-            all_matches.len()
+            all_matches.len(),
+            truncated
         );
 
-        Ok(crate::model::TextSearchResponse {
-            matches: all_matches,
-            page_data: None, // We've aggregated all pages
-            filter_data: None,
-        })
+        // All pages have been aggregated into a single result set; keep the
+        // endpoint-reported total for informational purposes.
+        let page_data = total_available.map(|total| crate::model::PageData {
+            total,
+            per_page,
+            current_page: 1,
+            last_page: 1,
+            start_index: 0,
+            end_index: all_matches.len(),
+        });
+
+        Ok((
+            crate::model::TextSearchResponse {
+                matches: all_matches,
+                page_data,
+                filter_data: None,
+            },
+            truncated,
+        ))
     }
 
     /// Create multiple assets by uploading files matching a glob pattern


### PR DESCRIPTION
## Summary

`asset text-match` silently truncated results at the default `--limit 100`. Because the Physna text-search endpoint ranks name matches above metadata-only matches, assets matching only in metadata ranked past position 100 and were dropped without any indication (found while investigating an asset whose "MOTOR" match lives in its `DESLOG3` metadata value — it ranked ~203rd of 214).

- Raise the default `--limit` for `asset text-match` from 100 to 1000; the limit remains as a guard against excessive queries. Visual-match commands keep their default of 100.
- Print a warning to **stderr** when the limit cuts the result set short, so data piped from stdout is unaffected:
  `⚠️  Result limit reached: showing the first 100 matching assets; increase --limit to retrieve more`
- Detect truncation from pagination state (stopped before the last page, or overshoot capped) rather than the endpoint-reported `pageData.total`, which can overcount the actually retrievable matches (observed: total 268 reported, 214 retrievable) and would trigger false warnings.
- `text_search` now also returns the endpoint-reported total via `page_data` for informational purposes.

## Testing

Verified against a live tenant with the "MOTOR" query:
- Default run: 214 results, previously-missing asset included, no warning.
- `--limit 100`: 100 results plus the stderr warning.
- `--limit 5`: 5 results plus the stderr warning.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)