### PR TITLE
Release v1.13.0 - --recursive for folder match reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-07-30
+
+### Added
+- **`--recursive` for folder match reports** - `folder geometric-match`, `folder part-match`, and `folder visual-match` accept `--recursive` (`-R`) to include the assets in every subfolder, not just those sitting directly in the named folder. The default is unchanged, so existing commands keep their current scope and runtime; recursion is opt-in because it can widen the work dramatically (a folder with a single asset of its own may have thousands underneath it, and each one costs a search).
+
+### Fixed
+- **Folder match reports no longer look like a broken path on container folders** - A folder that holds nothing but subfolders has no assets of its own, so a match report over it found nothing and failed with `No assets found in the specified folder(s)`, whose first suggestion was to verify the folder path. The path had in fact resolved correctly, which sent users hunting for a typo that was never there. The message now reports how many subfolders the folder actually contains and points at `--recursive`:
+
+  ```
+  ❌ Error: No assets found directly in the specified folder(s)
+
+  🔧 To resolve this issue, try the following:
+    1. The folder(s) contain 8 subfolder(s) - pass --recursive to include the assets in them
+  ```
+
 ## [1.12.0] - 2026-07-20
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.12.0"
+version = "1.13.0"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/docs/src/geometric-matching.md
+++ b/docs/src/geometric-matching.md
@@ -137,6 +137,32 @@ Find geometrically similar assets for all assets in a specified folder. This com
 pcli2 asset geometric-match-folder --folder-path /Root/SearchFolder/ --threshold 85.0
 ```
 
+### Including Subfolders
+
+By default only the assets sitting **directly** in the named folder are matched.
+A folder that holds nothing but subfolders therefore produces no report:
+
+```bash
+# /Creo Files contains 8 subfolders and no assets of its own
+pcli2 folder geometric-match --folder-path "/Creo Files" --threshold 85.0
+# ❌ Error: No assets found directly in the specified folder(s)
+#    1. The folder(s) contain 8 subfolder(s) - pass --recursive to include the assets in them
+```
+
+Pass `--recursive` (`-R`) to walk the whole subtree:
+
+```bash
+# Matches every asset under /Creo Files, including all of its subfolders
+pcli2 folder geometric-match --folder-path "/Creo Files" --threshold 85.0 --recursive
+```
+
+> `--recursive` can widen the scope dramatically — a folder with one asset of its
+> own may have thousands underneath it, and each one costs a search. Raise
+> `--concurrent` (up to 10) to speed it up, or name a deeper folder to narrow the
+> scope.
+
+The same flag is available on `folder part-match` and `folder visual-match`.
+
 ### Comparison Viewer URL
 
 Both `geometric-match` and `geometric-match-folder` commands include a comparison URL in their output that allows you to view the geometric match in the Physna UI. The URL is available in both JSON and CSV formats:

--- a/src/actions/assets/match_ops.rs
+++ b/src/actions/assets/match_ops.rs
@@ -19,6 +19,119 @@ use crate::{
 use clap::ArgMatches;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use tracing::trace;
+use uuid::Uuid;
+
+/// Count the direct subfolders of the given folder paths.
+///
+/// Used only to make the "no assets found" message actionable: a folder that holds
+/// nothing but subfolders looks empty to a non-recursive report, and the user needs to
+/// be told that `--recursive` is what they want. Returns 0 if the hierarchy is
+/// unavailable, which merely costs a less specific message.
+async fn count_subfolders(
+    api: &mut PhysnaApiClient,
+    tenant_uuid: &Uuid,
+    folder_paths: &[String],
+) -> usize {
+    let Ok(hierarchy) = crate::folder_cache::FolderCache::get_or_fetch(api, tenant_uuid).await
+    else {
+        return 0;
+    };
+
+    folder_paths
+        .iter()
+        .map(|folder_path| {
+            let normalized = crate::model::normalize_path(folder_path);
+            if normalized == "/" {
+                return hierarchy.root_uuids.len();
+            }
+            let lookup = normalized.strip_prefix('/').unwrap_or(&normalized);
+            hierarchy
+                .get_folder_by_path(lookup)
+                .map(|node| node.children.len())
+                .unwrap_or(0)
+        })
+        .sum()
+}
+
+/// Collect the assets to report on from the given folder paths.
+///
+/// By default this is only the assets sitting directly in each folder, matching the
+/// Physna contents endpoint. With `recursive` it is every asset in the subtree, which is
+/// what a container folder holding nothing but subfolders needs to produce any output.
+///
+/// Assets are keyed by UUID, so a folder path that overlaps another one supplied on the
+/// same command line contributes each asset only once.
+///
+/// # Returns
+/// * `Ok(Some(assets))` - The assets found, guaranteed non-empty
+/// * `Ok(None)` - Nothing was found; remediation advice has already been printed and the
+///   caller should return without producing a report
+/// * `Err(CliError)` - A path did not resolve, or an API call failed
+async fn collect_assets_in_folders(
+    api: &mut PhysnaApiClient,
+    tenant_uuid: &Uuid,
+    folder_paths: &[String],
+    recursive: bool,
+) -> Result<Option<std::collections::HashMap<Uuid, crate::model::Asset>>, CliError> {
+    let mut all_assets = std::collections::HashMap::new();
+
+    for folder_path in folder_paths {
+        trace!(
+            "Listing assets for folder path: {} (recursive: {})",
+            folder_path,
+            recursive
+        );
+        let assets_response = if recursive {
+            api.list_assets_by_parent_folder_path_recursive(tenant_uuid, folder_path.as_str())
+                .await?
+        } else {
+            api.list_assets_by_parent_folder_path(tenant_uuid, folder_path.as_str())
+                .await?
+        };
+
+        for asset in assets_response.get_all_assets() {
+            all_assets.insert(asset.uuid(), asset.clone());
+        }
+    }
+
+    trace!("Found {} assets across all folders", all_assets.len());
+
+    if all_assets.is_empty() {
+        // The paths themselves resolved - listing returns `FolderNotFound` otherwise -
+        // so this is a genuinely empty result, not a typo in the path.
+        let subfolders = if recursive {
+            0
+        } else {
+            count_subfolders(api, tenant_uuid, folder_paths).await
+        };
+
+        if subfolders > 0 {
+            error_utils::report_error_with_remediation(
+                &"No assets found directly in the specified folder(s)",
+                &[
+                    &format!(
+                        "The folder(s) contain {} subfolder(s) - pass --recursive to include the assets in them",
+                        subfolders
+                    ),
+                    "Run 'pcli2 folder list --folder-path <path>' to see what the folder contains",
+                    "Ensure you have permissions to access the specified folder(s)",
+                ],
+            );
+        } else {
+            error_utils::report_error_with_remediation(
+                &"No assets found in the specified folder(s)",
+                &[
+                    "Run 'pcli2 folder list --folder-path <path>' to see what the folder contains",
+                    "Check that the assets have finished processing ('pcli2 asset list' shows their state)",
+                    "Ensure you have permissions to access the specified folder(s)",
+                ],
+            );
+        }
+        return Ok(None);
+    }
+
+    Ok(Some(all_assets))
+}
 
 /// Perform geometric matching on a single asset.
 ///
@@ -705,33 +818,15 @@ pub async fn geometric_match_folder(sub_matches: &ArgMatches) -> Result<(), CliE
 
     let show_progress = sub_matches.get_flag("progress");
 
-    // Collect all assets from the specified folders
-    let mut all_assets = std::collections::HashMap::new();
+    let recursive = sub_matches.get_flag(crate::commands::params::PARAMETER_RECURSIVE);
 
-    for folder_path in &folder_paths {
-        trace!("Listing assets for folder path: {}", folder_path);
-        let assets_response = api
-            .list_assets_by_parent_folder_path(&tenant.uuid, folder_path.as_str())
-            .await?;
-
-        for asset in assets_response.get_all_assets() {
-            all_assets.insert(asset.uuid(), asset.clone());
-        }
-    }
-
-    trace!("Found {} assets across all folders", all_assets.len());
-
-    if all_assets.is_empty() {
-        error_utils::report_error_with_remediation(
-            &"No assets found in the specified folder(s)",
-            &[
-                "Verify the folder path is correct",
-                "Check that the folder contains assets",
-                "Ensure you have permissions to access the specified folder(s)",
-            ],
-        );
-        return Ok(());
-    }
+    // Collect all assets from the specified folders, descending into subfolders only
+    // when --recursive was requested
+    let all_assets =
+        match collect_assets_in_folders(&mut api, &tenant.uuid, &folder_paths, recursive).await? {
+            Some(assets) => assets,
+            None => return Ok(()),
+        };
 
     // Create multi-progress bar if show_progress is true
     let multi_progress = if show_progress {
@@ -1208,33 +1303,15 @@ pub async fn part_match_folder(sub_matches: &ArgMatches) -> Result<(), CliError>
 
     let show_progress = sub_matches.get_flag("progress");
 
-    // Collect all assets from the specified folders
-    let mut all_assets = std::collections::HashMap::new();
+    let recursive = sub_matches.get_flag(crate::commands::params::PARAMETER_RECURSIVE);
 
-    for folder_path in &folder_paths {
-        trace!("Listing assets for folder path: {}", folder_path);
-        let assets_response = api
-            .list_assets_by_parent_folder_path(&tenant.uuid, folder_path.as_str())
-            .await?;
-
-        for asset in assets_response.get_all_assets() {
-            all_assets.insert(asset.uuid(), asset.clone());
-        }
-    }
-
-    trace!("Found {} assets across all folders", all_assets.len());
-
-    if all_assets.is_empty() {
-        error_utils::report_error_with_remediation(
-            &"No assets found in the specified folder(s)",
-            &[
-                "Verify the folder path is correct",
-                "Check that the folder contains assets",
-                "Ensure you have permissions to access the specified folder(s)",
-            ],
-        );
-        return Ok(());
-    }
+    // Collect all assets from the specified folders, descending into subfolders only
+    // when --recursive was requested
+    let all_assets =
+        match collect_assets_in_folders(&mut api, &tenant.uuid, &folder_paths, recursive).await? {
+            Some(assets) => assets,
+            None => return Ok(()),
+        };
 
     // Create multi-progress bar if show_progress is true
     let multi_progress = if show_progress {
@@ -1748,33 +1825,15 @@ pub async fn visual_match_folder(sub_matches: &ArgMatches) -> Result<(), CliErro
 
     let show_progress = sub_matches.get_flag("progress");
 
-    // Collect all assets from the specified folders
-    let mut all_assets = std::collections::HashMap::new();
+    let recursive = sub_matches.get_flag(crate::commands::params::PARAMETER_RECURSIVE);
 
-    for folder_path in &folder_paths {
-        trace!("Listing assets for folder path: {}", folder_path);
-        let assets_response = api
-            .list_assets_by_parent_folder_path(&tenant.uuid, folder_path.as_str())
-            .await?;
-
-        for asset in assets_response.get_all_assets() {
-            all_assets.insert(asset.uuid(), asset.clone());
-        }
-    }
-
-    trace!("Found {} assets across all folders", all_assets.len());
-
-    if all_assets.is_empty() {
-        error_utils::report_error_with_remediation(
-            &"No assets found in the specified folder(s)",
-            &[
-                "Verify the folder path is correct",
-                "Check that the folder contains assets",
-                "Ensure you have permissions to access the specified folder(s)",
-            ],
-        );
-        return Ok(());
-    }
+    // Collect all assets from the specified folders, descending into subfolders only
+    // when --recursive was requested
+    let all_assets =
+        match collect_assets_in_folders(&mut api, &tenant.uuid, &folder_paths, recursive).await? {
+            Some(assets) => assets,
+            None => return Ok(()),
+        };
 
     // Create multi-progress bar if show_progress is true
     let multi_progress = if show_progress {

--- a/src/commands/folder.rs
+++ b/src/commands/folder.rs
@@ -229,6 +229,7 @@ pub fn folder_command() -> Command {
                         .help("Folder path(s) to process (can be provided multiple times or as comma-separated values)")
                         .action(clap::ArgAction::Append), // Allow multiple --path flags
                 )
+                .arg(crate::commands::params::recursive_parameter())
                 .arg(
                     clap::Arg::new("threshold")
                         .short('s')
@@ -284,6 +285,7 @@ pub fn folder_command() -> Command {
                         .help("Folder path(s) to process (can be provided multiple times or as comma-separated values)")
                         .action(clap::ArgAction::Append), // Allow multiple --path flags
                 )
+                .arg(crate::commands::params::recursive_parameter())
                 .arg(
                     clap::Arg::new("threshold")
                         .short('s')
@@ -347,6 +349,7 @@ pub fn folder_command() -> Command {
                         .help("Folder path(s) to process (can be provided multiple times or as comma-separated values)")
                         .action(clap::ArgAction::Append), // Allow multiple --path flags
                 )
+                .arg(crate::commands::params::recursive_parameter())
                 .arg(
                     clap::Arg::new("exclusive")
                         .long("exclusive")

--- a/src/commands/params.rs
+++ b/src/commands/params.rs
@@ -473,13 +473,17 @@ pub fn refresh_parameter() -> Arg {
 }
 
 /// Create the recursive parameter.
+///
+/// Folder-wide reports only look at the assets sitting directly in the named folder.
+/// This flag extends them to every subfolder as well, which is what a folder that holds
+/// nothing but subfolders needs in order to produce any output at all.
 pub fn recursive_parameter() -> Arg {
     Arg::new(PARAMETER_RECURSIVE)
         .short('R')
         .long(PARAMETER_RECURSIVE)
         .action(ArgAction::SetTrue)
         .required(false)
-        .help("Recursively apply operation (default: false for CSV/JSON, true for tree)")
+        .help("Include assets in subfolders, not just those directly in the folder")
 }
 
 /// Create the API URL parameter.

--- a/src/folder_hierarchy.rs
+++ b/src/folder_hierarchy.rs
@@ -243,6 +243,63 @@ impl FolderHierarchy {
         self.nodes.get(uuid)
     }
 
+    /// Collect the UUIDs of a folder and every folder beneath it, breadth-first.
+    ///
+    /// The starting folder is always the first element. Folders already visited are
+    /// skipped, so a malformed hierarchy containing a cycle terminates rather than
+    /// looping forever.
+    ///
+    /// # Arguments
+    /// * `root_uuid` - The folder to start from
+    ///
+    /// # Returns
+    /// The starting folder's UUID followed by all of its descendants. Empty if the
+    /// starting folder is not part of this hierarchy.
+    pub fn subtree_uuids(&self, root_uuid: &Uuid) -> Vec<Uuid> {
+        if !self.nodes.contains_key(root_uuid) {
+            return Vec::new();
+        }
+
+        let mut visited = std::collections::HashSet::new();
+        let mut queue = std::collections::VecDeque::new();
+        let mut ordered = Vec::new();
+
+        queue.push_back(*root_uuid);
+        visited.insert(*root_uuid);
+
+        while let Some(uuid) = queue.pop_front() {
+            ordered.push(uuid);
+            if let Some(node) = self.nodes.get(&uuid) {
+                for child in &node.children {
+                    if visited.insert(*child) {
+                        queue.push_back(*child);
+                    }
+                }
+            }
+        }
+
+        ordered
+    }
+
+    /// Collect the UUIDs of every folder in the hierarchy, breadth-first from each root.
+    ///
+    /// Used when an operation targets the tenant root, which has no folder UUID of its
+    /// own but conceptually contains every folder.
+    pub fn all_subtree_uuids(&self) -> Vec<Uuid> {
+        let mut visited = std::collections::HashSet::new();
+        let mut ordered = Vec::new();
+
+        for root_uuid in &self.root_uuids {
+            for uuid in self.subtree_uuids(root_uuid) {
+                if visited.insert(uuid) {
+                    ordered.push(uuid);
+                }
+            }
+        }
+
+        ordered
+    }
+
     /// Get a folder node by its path
     ///
     /// # Arguments
@@ -602,5 +659,96 @@ mod tests {
         assert!(hierarchy
             .get_folder_by_path("parent/Child Folder")
             .is_some());
+    }
+
+    /// Build a folder with the given name, parent and children, for traversal tests.
+    fn folder(name: &str, parent: Option<Uuid>) -> FolderResponse {
+        FolderResponse {
+            uuid: Uuid::new_v4(),
+            tenant_uuid: Uuid::new_v4(),
+            name: name.to_string(),
+            created_at: String::new(),
+            updated_at: String::new(),
+            assets_count: 0,
+            folders_count: 0,
+            parent_folder_uuid: parent,
+            owner_id: None,
+        }
+    }
+
+    /// Assemble a hierarchy from `(node, children)` pairs.
+    fn hierarchy_of(folders: Vec<FolderResponse>, edges: &[(Uuid, Uuid)]) -> FolderHierarchy {
+        let mut nodes = HashMap::new();
+        let mut root_uuids = Vec::new();
+
+        for folder in folders {
+            if folder.parent_folder_uuid.is_none() {
+                root_uuids.push(folder.uuid);
+            }
+            nodes.insert(folder.uuid, FolderNode::new(folder));
+        }
+
+        for (parent, child) in edges {
+            nodes.get_mut(parent).unwrap().children.push(*child);
+        }
+
+        FolderHierarchy { nodes, root_uuids }
+    }
+
+    #[test]
+    fn subtree_uuids_includes_the_folder_and_every_descendant() {
+        // Regression: folder match reports listed only a folder's direct assets, so a
+        // container folder such as "Creo Files" - which holds nothing but subfolders -
+        // reported zero assets even though its subtree was full of them.
+        let root = folder("Creo Files", None);
+        let root_uuid = root.uuid;
+        let child = folder("Demo - Local", Some(root_uuid));
+        let child_uuid = child.uuid;
+        let grandchild = folder("Nested", Some(child_uuid));
+        let grandchild_uuid = grandchild.uuid;
+        let sibling = folder("Creo", None);
+        let sibling_uuid = sibling.uuid;
+
+        let hierarchy = hierarchy_of(
+            vec![root, child, grandchild, sibling],
+            &[(root_uuid, child_uuid), (child_uuid, grandchild_uuid)],
+        );
+
+        let subtree = hierarchy.subtree_uuids(&root_uuid);
+        assert_eq!(subtree.len(), 3);
+        assert_eq!(subtree[0], root_uuid, "the folder itself comes first");
+        assert!(subtree.contains(&child_uuid));
+        assert!(subtree.contains(&grandchild_uuid));
+        assert!(
+            !subtree.contains(&sibling_uuid),
+            "an unrelated root folder must not be pulled in"
+        );
+
+        // A leaf folder is its own complete subtree.
+        assert_eq!(
+            hierarchy.subtree_uuids(&grandchild_uuid),
+            vec![grandchild_uuid]
+        );
+
+        // Every root's subtree, with no duplicates.
+        let all = hierarchy.all_subtree_uuids();
+        assert_eq!(all.len(), 4);
+    }
+
+    #[test]
+    fn subtree_uuids_handles_unknown_folders_and_cycles() {
+        assert!(FolderHierarchy::new()
+            .subtree_uuids(&Uuid::new_v4())
+            .is_empty());
+
+        // A malformed hierarchy whose children loop back must terminate rather than
+        // recursing forever.
+        let a = folder("a", None);
+        let a_uuid = a.uuid;
+        let b = folder("b", Some(a_uuid));
+        let b_uuid = b.uuid;
+        let hierarchy = hierarchy_of(vec![a, b], &[(a_uuid, b_uuid), (b_uuid, a_uuid)]);
+
+        assert_eq!(hierarchy.subtree_uuids(&a_uuid), vec![a_uuid, b_uuid]);
     }
 }

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -14,7 +14,7 @@ use reqwest;
 use serde_json;
 use serde_urlencoded;
 use std::path::Path;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
 /// Error emitted by the Physna V3 Api
@@ -1685,6 +1685,94 @@ impl PhysnaApiClient {
         let assets = self
             .list_assets_by_parent_folder_uuid(tenant_uuid, parent_folder_uuid.clone().as_ref())
             .await?;
+        Ok(assets)
+    }
+
+    /// List the assets in a folder *and* in every folder beneath it.
+    ///
+    /// The Physna contents endpoint only ever returns a folder's direct children, so a
+    /// container folder that holds nothing but subfolders reports zero assets. This
+    /// method walks the cached folder hierarchy and queries each folder in the subtree,
+    /// which is what folder-wide reports (match reports in particular) need.
+    ///
+    /// # Arguments
+    /// * `tenant_uuid` - The UUID of the tenant
+    /// * `parent_folder_path` - The path of the folder to list assets from. The tenant
+    ///   root (`/`) means every folder in the tenant, plus any assets sitting at root.
+    ///
+    /// # Returns
+    /// * `Ok(AssetList)` - Every asset in the subtree, de-duplicated by UUID
+    /// * `Err(ApiError)` - If the path does not resolve, or an API call fails
+    pub async fn list_assets_by_parent_folder_path_recursive(
+        &mut self,
+        tenant_uuid: &Uuid,
+        parent_folder_path: &str,
+    ) -> Result<AssetList, ApiError> {
+        debug!(
+            "Recursively listing assets in a folder by path: {} for tenant: {}",
+            parent_folder_path, tenant_uuid
+        );
+
+        // Resolve first so a bad path still fails with FolderNotFound rather than
+        // silently returning an empty list.
+        let parent_folder_uuid = self
+            .resolve_folder_uuid_by_path(tenant_uuid, parent_folder_path)
+            .await?;
+
+        // Without the hierarchy there is no way to enumerate descendants, so fall back
+        // to the direct-children behaviour rather than failing the whole report.
+        let hierarchy = match crate::folder_cache::FolderCache::get_or_fetch(self, tenant_uuid)
+            .await
+        {
+            Ok(hierarchy) => Some(hierarchy),
+            Err(e) => {
+                warn!(
+                    "Could not load the folder hierarchy ({}); listing only the assets directly in '{}'",
+                    e, parent_folder_path
+                );
+                None
+            }
+        };
+
+        let (subtree_uuids, include_root_level) = match (hierarchy, parent_folder_uuid.as_ref()) {
+            // A resolved folder: that folder plus all of its descendants.
+            (Some(hierarchy), Some(uuid)) => (hierarchy.subtree_uuids(uuid), false),
+            // The tenant root has no UUID of its own; it covers every folder, and
+            // assets can also live at root level with no parent folder at all.
+            (Some(hierarchy), None) => (hierarchy.all_subtree_uuids(), true),
+            (None, Some(uuid)) => (vec![*uuid], false),
+            (None, None) => (Vec::new(), true),
+        };
+
+        let mut assets = AssetList::empty();
+
+        if include_root_level {
+            for asset in self
+                .list_assets_by_parent_folder_uuid(tenant_uuid, None)
+                .await?
+                .get_all_assets()
+            {
+                assets.insert(asset.clone());
+            }
+        }
+
+        for folder_uuid in &subtree_uuids {
+            for asset in self
+                .list_assets_by_parent_folder_uuid(tenant_uuid, Some(folder_uuid))
+                .await?
+                .get_all_assets()
+            {
+                assets.insert(asset.clone());
+            }
+        }
+
+        debug!(
+            "Found {} assets across {} folder(s) under path: {}",
+            assets.len(),
+            subtree_uuids.len(),
+            parent_folder_path
+        );
+
         Ok(assets)
     }
 


### PR DESCRIPTION
## Release v1.13.0

### Added
- **`--recursive` for folder match reports** — `folder geometric-match`, `folder part-match`, and `folder visual-match` accept `--recursive` (`-R`) to include the assets in every subfolder, not just those sitting directly in the named folder.

  The default is unchanged, so existing commands keep their current scope and runtime. Recursion is opt-in because it can widen the work dramatically: one test folder goes from **1 asset to 241**, and at the default `--concurrent 1` that is 241 serial searches.

### Fixed
- **Folder match reports no longer look like a broken path on container folders** — a user reported that `folder geometric-match` "fails to resolve the path" for a folder that clearly exists. It didn't; the path resolved fine.

  A folder holding nothing but subfolders has no assets of its own, so the report found nothing and failed with `No assets found in the specified folder(s)` — whose first suggestion was to verify the folder path. That sent the reporter hunting for a typo that was never there. The message now names the real situation:

  ```
  ❌ Error: No assets found directly in the specified folder(s)

  🔧 To resolve this issue, try the following:
    1. The folder(s) contain 8 subfolder(s) - pass --recursive to include the assets in them
    2. Run 'pcli2 folder list --folder-path <path>' to see what the folder contains
    3. Ensure you have permissions to access the specified folder(s)
  ```

## Contents

Merges #67.

## Verification

Against a live tenant:

| Command | Assets collected |
|---|---|
| `--folder-path "/TCS TEST"` | 1 (unchanged from v1.12.0) |
| `--folder-path "/TCS TEST" --recursive` | 241 |
| `--folder-path "/Creo Files"` | 0 → new message naming the 8 subfolders |

Local gate before pushing: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full test suite (116 lib + all integration tests, including 2 new hierarchy tests) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)