### PR TITLE
feat(folder-match): report recursive folder scan under --progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`--progress` now covers the recursive folder scan** - With `--recursive`, folder match reports spend time walking the folder tree (one API call per folder) before any matching starts, which looked like a hang on a deep tree. When `--progress` is passed, that phase now reports live (`Scanning /Creo Files: 46/312 folders, 1174 assets found`) and prints a summary before matching begins (`Scanned 1 folder path(s), found 3182 asset(s) to match`). All of it goes to stderr, so piped `stdout` is unaffected; without `--progress` the scan stays silent.
+
 ## [1.13.0] - 2026-07-30
 
 ### Added

--- a/docs/src/geometric-matching.md
+++ b/docs/src/geometric-matching.md
@@ -252,6 +252,23 @@ When using both `--concurrent` and `--progress` flags together, the command will
 - Individual progress bars for each concurrent operation showing which assets are being processed
 - Status messages indicating the current stage of each operation (starting search, processing matches, completion)
 
+With `--recursive`, `--progress` also covers the folder scan that happens *before*
+any matching starts. A deep tree costs one API call per folder, so this phase can
+run for a while on its own:
+
+```
+⠹ Scanning /Creo Files: 46/312 folders, 1174 assets found
+```
+
+followed by a summary once the scan completes:
+
+```
+Scanned 1 folder path(s), found 3182 asset(s) to match
+```
+
+All of this goes to `stderr`, so piping `stdout` to a file or another command is
+unaffected. Without `--progress` the scan is silent.
+
 #### Performance Options
 
 ##### Concurrency and Progress Combined

--- a/src/actions/assets/match_ops.rs
+++ b/src/actions/assets/match_ops.rs
@@ -62,6 +62,10 @@ async fn count_subfolders(
 /// Assets are keyed by UUID, so a folder path that overlaps another one supplied on the
 /// same command line contributes each asset only once.
 ///
+/// A recursive scan costs one API call per folder in the subtree and runs before any
+/// matching starts, so with `show_progress` it reports what it is doing. Without the
+/// flag it stays silent, keeping the default output unchanged.
+///
 /// # Returns
 /// * `Ok(Some(assets))` - The assets found, guaranteed non-empty
 /// * `Ok(None)` - Nothing was found; remediation advice has already been printed and the
@@ -72,8 +76,18 @@ async fn collect_assets_in_folders(
     tenant_uuid: &Uuid,
     folder_paths: &[String],
     recursive: bool,
+    show_progress: bool,
 ) -> Result<Option<std::collections::HashMap<Uuid, crate::model::Asset>>, CliError> {
     let mut all_assets = std::collections::HashMap::new();
+
+    // Only a recursive scan is slow enough to need reporting; the non-recursive path is
+    // a single call per folder. The spinner hides itself when stderr is not a terminal,
+    // so redirected output stays clean.
+    let scan_progress = if recursive && show_progress {
+        Some(crate::terminal::spinner("Scanning folders..."))
+    } else {
+        None
+    };
 
     for folder_path in folder_paths {
         trace!(
@@ -82,8 +96,21 @@ async fn collect_assets_in_folders(
             recursive
         );
         let assets_response = if recursive {
-            api.list_assets_by_parent_folder_path_recursive(tenant_uuid, folder_path.as_str())
-                .await?
+            let path_label = folder_path.clone();
+            let progress = scan_progress.as_ref();
+            api.list_assets_by_parent_folder_path_recursive(
+                tenant_uuid,
+                folder_path.as_str(),
+                |scanned, total, assets| {
+                    if let Some(progress) = progress {
+                        progress.set_message(format!(
+                            "Scanning {}: {}/{} folders, {} assets found",
+                            path_label, scanned, total, assets
+                        ));
+                    }
+                },
+            )
+            .await?
         } else {
             api.list_assets_by_parent_folder_path(tenant_uuid, folder_path.as_str())
                 .await?
@@ -92,6 +119,16 @@ async fn collect_assets_in_folders(
         for asset in assets_response.get_all_assets() {
             all_assets.insert(asset.uuid(), asset.clone());
         }
+    }
+
+    // Clear the spinner before the match progress bars take over the terminal.
+    if let Some(progress) = scan_progress {
+        progress.finish_and_clear();
+        eprintln!(
+            "Scanned {} folder path(s), found {} asset(s) to match",
+            folder_paths.len(),
+            all_assets.len()
+        );
     }
 
     trace!("Found {} assets across all folders", all_assets.len());
@@ -822,11 +859,18 @@ pub async fn geometric_match_folder(sub_matches: &ArgMatches) -> Result<(), CliE
 
     // Collect all assets from the specified folders, descending into subfolders only
     // when --recursive was requested
-    let all_assets =
-        match collect_assets_in_folders(&mut api, &tenant.uuid, &folder_paths, recursive).await? {
-            Some(assets) => assets,
-            None => return Ok(()),
-        };
+    let all_assets = match collect_assets_in_folders(
+        &mut api,
+        &tenant.uuid,
+        &folder_paths,
+        recursive,
+        show_progress,
+    )
+    .await?
+    {
+        Some(assets) => assets,
+        None => return Ok(()),
+    };
 
     // Create multi-progress bar if show_progress is true
     let multi_progress = if show_progress {
@@ -1307,11 +1351,18 @@ pub async fn part_match_folder(sub_matches: &ArgMatches) -> Result<(), CliError>
 
     // Collect all assets from the specified folders, descending into subfolders only
     // when --recursive was requested
-    let all_assets =
-        match collect_assets_in_folders(&mut api, &tenant.uuid, &folder_paths, recursive).await? {
-            Some(assets) => assets,
-            None => return Ok(()),
-        };
+    let all_assets = match collect_assets_in_folders(
+        &mut api,
+        &tenant.uuid,
+        &folder_paths,
+        recursive,
+        show_progress,
+    )
+    .await?
+    {
+        Some(assets) => assets,
+        None => return Ok(()),
+    };
 
     // Create multi-progress bar if show_progress is true
     let multi_progress = if show_progress {
@@ -1829,11 +1880,18 @@ pub async fn visual_match_folder(sub_matches: &ArgMatches) -> Result<(), CliErro
 
     // Collect all assets from the specified folders, descending into subfolders only
     // when --recursive was requested
-    let all_assets =
-        match collect_assets_in_folders(&mut api, &tenant.uuid, &folder_paths, recursive).await? {
-            Some(assets) => assets,
-            None => return Ok(()),
-        };
+    let all_assets = match collect_assets_in_folders(
+        &mut api,
+        &tenant.uuid,
+        &folder_paths,
+        recursive,
+        show_progress,
+    )
+    .await?
+    {
+        Some(assets) => assets,
+        None => return Ok(()),
+    };
 
     // Create multi-progress bar if show_progress is true
     let multi_progress = if show_progress {

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -1699,15 +1699,23 @@ impl PhysnaApiClient {
     /// * `tenant_uuid` - The UUID of the tenant
     /// * `parent_folder_path` - The path of the folder to list assets from. The tenant
     ///   root (`/`) means every folder in the tenant, plus any assets sitting at root.
+    /// * `on_progress` - Called after each folder in the subtree is queried, with
+    ///   `(folders_scanned, folders_total, assets_so_far)`. A deep tree takes one API
+    ///   call per folder, so a caller showing a progress display needs this to avoid
+    ///   looking hung. Pass `|_, _, _| {}` when there is nothing to report to.
     ///
     /// # Returns
     /// * `Ok(AssetList)` - Every asset in the subtree, de-duplicated by UUID
     /// * `Err(ApiError)` - If the path does not resolve, or an API call fails
-    pub async fn list_assets_by_parent_folder_path_recursive(
+    pub async fn list_assets_by_parent_folder_path_recursive<F>(
         &mut self,
         tenant_uuid: &Uuid,
         parent_folder_path: &str,
-    ) -> Result<AssetList, ApiError> {
+        mut on_progress: F,
+    ) -> Result<AssetList, ApiError>
+    where
+        F: FnMut(usize, usize, usize),
+    {
         debug!(
             "Recursively listing assets in a folder by path: {} for tenant: {}",
             parent_folder_path, tenant_uuid
@@ -1746,6 +1754,11 @@ impl PhysnaApiClient {
 
         let mut assets = AssetList::empty();
 
+        // The root level is an extra query on top of the subtree folders, so it counts
+        // towards the total the caller is shown.
+        let total = subtree_uuids.len() + usize::from(include_root_level);
+        let mut scanned = 0;
+
         if include_root_level {
             for asset in self
                 .list_assets_by_parent_folder_uuid(tenant_uuid, None)
@@ -1754,6 +1767,8 @@ impl PhysnaApiClient {
             {
                 assets.insert(asset.clone());
             }
+            scanned += 1;
+            on_progress(scanned, total, assets.len());
         }
 
         for folder_uuid in &subtree_uuids {
@@ -1764,6 +1779,8 @@ impl PhysnaApiClient {
             {
                 assets.insert(asset.clone());
             }
+            scanned += 1;
+            on_progress(scanned, total, assets.len());
         }
 
         debug!(


### PR DESCRIPTION
## Problem

A recursive folder match walks the folder tree before any matching starts, at one API call per folder. On a deep tree that phase runs for minutes on its own — and because the existing progress bars only cover the *matching*, the command looks hung the whole time.

This came up immediately after v1.13.0 shipped: `/Creo Files` has 57+ subfolders under one child alone, and a run against it sits silent well before the first search fires.

## Change

When `--progress` is passed alongside `--recursive`, the scan now reports live:

```
⠹ Scanning /Creo Files: 46/312 folders, 1174 assets found
```

and prints a summary before matching begins:

```
Scanned 1 folder path(s), found 3182 asset(s) to match
```

Gated strictly on `--progress`, per the request — without the flag the scan is silent and default output is byte-for-byte unchanged.

## Notes

- Everything goes to **stderr**, so piping `stdout` to a file or another command is unaffected.
- The spinner uses the existing `terminal::spinner` helper, which hides itself when stderr is not a TTY — so redirected output and CI logs don't collect spinner frames.
- The spinner is cleared before the match progress bars take over the terminal.
- `list_assets_by_parent_folder_path_recursive` gained a progress callback (`FnMut(scanned, total, assets)`) rather than a dependency on `indicatif`, keeping the API client free of display concerns. The non-recursive path is a single call per folder and needs no reporting.

## Verification

Against a live tenant, `--folder-path "/TCS TEST" --recursive`:

| Invocation | Result |
|---|---|
| `--progress`, stderr | `Scanned 1 folder path(s), found 241 asset(s) to match` |
| `--progress`, stdout | clean CSV, no progress output mixed in |
| no `--progress`, stderr | silent (0 lines) |

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and all 11 test targets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)