### PR TITLE
Stop materializing an intermediate copy of every match; refuse oversized xls reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`folder geometric-match --format xls` now refuses a report too tall for a worksheet, instead of failing deep inside the workbook writer** - An Excel worksheet holds 1,048,576 rows; this report spends two of them on its header band, leaving 1,048,574 for data. A real run produced 1,293,068 rows, which cannot be represented. The command now fails immediately after matching with `the report has 1293068 rows, more than the 1048574 an Excel worksheet can hold - use '--format csv' for the complete report`, before building a single row. Truncating to fit was considered and rejected: a workbook silently missing a quarter of its rows looks complete to whoever opens it. Use `--format csv`, which has no such limit.
+
+### Fixed
+- **Report building no longer materializes an intermediate copy of every match** - `folder geometric-match` built a `Vec<GeometricMatchPair>` before building rows, cloning each reference asset — metadata `HashMap` included — once per row, only ever to read a path and a UUID back out of it. On a 1.29M-row report that intermediate took seconds to build and a further nine seconds to *drop*, with the progress display parked at 99% for the whole teardown. Both passes now iterate borrowed data. Output is unchanged.
+- **The progress bar no longer flashes `0/0 (0%)` when a counted phase starts** - The steady-tick thread could redraw in the window between the counter style being applied and the row count being set. Length is now set first.
+
 ## [1.15.0] - 2026-07-30
 
 ### Changed

--- a/src/actions/assets/match_ops.rs
+++ b/src/actions/assets/match_ops.rs
@@ -861,35 +861,42 @@ fn build_geometric_match_table(
     with_metadata: bool,
     progress: &ReportProgress,
 ) -> (Vec<String>, Vec<Vec<String>>) {
-    // Flatten every (reference, candidate) match into a single row model. Each pair
-    // clones its reference asset, metadata included, so this is not a cheap pass.
-    progress.phase(format!(
-        "Flattening {} matches...",
-        HumanCount(all_matches.len() as u64)
-    ));
-    let flattened: Vec<crate::model::GeometricMatchPair> = all_matches
-        .iter()
-        .flat_map(|response| {
-            response.matches.iter().map(move |m| {
-                crate::model::GeometricMatchPair::from_reference_and_match(
-                    response.reference_asset.clone(),
-                    m.clone(),
-                )
-            })
+    // Every (reference, candidate) pair, borrowed rather than materialized.
+    //
+    // This used to collect a `Vec<GeometricMatchPair>` first, which cloned the whole
+    // reference asset - metadata `HashMap` included - once per row, only ever to read
+    // a path and a UUID back out of it. On a 1.3M-row report that intermediate cost
+    // seconds to build and a further nine seconds to *drop* at the end of this
+    // function, with the progress display parked at 99% for all of it. Both passes
+    // below iterate the borrowed data instead, so nothing is duplicated and there is
+    // nothing to tear down.
+    //
+    // `GeometricMatchPair::from_reference_and_match` is a plain field mapping, so
+    // reading the fields directly here produces byte-identical rows.
+    let pairs = || {
+        all_matches.iter().flat_map(|response| {
+            response
+                .matches
+                .iter()
+                .map(move |m| (&response.reference_asset, m))
         })
-        .collect();
+    };
+    let total_rows: usize = all_matches
+        .iter()
+        .map(|response| response.matches.len())
+        .sum();
 
     // Collect the sorted, unique metadata keys present across all pairs.
     let mut metadata_keys: Vec<String> = Vec::new();
     if with_metadata {
-        progress.start_rows("Collecting metadata columns", flattened.len());
+        progress.start_rows("Collecting metadata columns", total_rows);
         let mut keys = std::collections::HashSet::new();
-        for (index, pair) in flattened.iter().enumerate() {
+        for (index, (reference_asset, match_result)) in pairs().enumerate() {
             progress.set_row(index);
-            for key in pair.reference_asset.metadata.keys() {
+            for key in reference_asset.metadata.keys() {
                 keys.insert(key.clone());
             }
-            for key in pair.candidate_asset.metadata.keys() {
+            for key in match_result.asset.metadata.keys() {
                 keys.insert(key.clone());
             }
         }
@@ -913,29 +920,28 @@ fn build_geometric_match_table(
     headers.push(COMPARISON_URL_HEADER.to_string());
 
     // Rows, in the same column order as the headers (COMPARISON_URL last).
-    progress.start_rows("Building rows", flattened.len());
-    let mut rows = Vec::with_capacity(flattened.len());
-    for (index, pair) in flattened.iter().enumerate() {
+    progress.start_rows("Building rows", total_rows);
+    let mut rows = Vec::with_capacity(total_rows);
+    for (index, (reference_asset, match_result)) in pairs().enumerate() {
         progress.set_row(index);
         let mut values = vec![
-            pair.reference_asset.path.clone(),
-            pair.candidate_asset.path.clone(),
-            format!("{}", pair.match_percentage),
-            pair.reference_asset.uuid.to_string(),
-            pair.candidate_asset.uuid.to_string(),
+            reference_asset.path.clone(),
+            match_result.asset.path.clone(),
+            format!("{}", match_result.match_percentage),
+            reference_asset.uuid.to_string(),
+            match_result.asset.uuid.to_string(),
         ];
         if with_metadata {
             for key in &metadata_keys {
-                let ref_value = pair
-                    .reference_asset
+                let ref_value = reference_asset
                     .metadata
                     .get(key)
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string())
                     .unwrap_or_default();
                 values.push(ref_value);
-                let candidate_value = pair
-                    .candidate_asset
+                let candidate_value = match_result
+                    .asset
                     .metadata
                     .get(key)
                     .and_then(|v| v.as_str())
@@ -945,7 +951,7 @@ fn build_geometric_match_table(
             }
         }
         // COMPARISON_URL last, matching the header order above.
-        values.push(pair.comparison_url.clone().unwrap_or_default());
+        values.push(match_result.comparison_url.clone().unwrap_or_default());
         rows.push(values);
     }
 
@@ -1346,6 +1352,17 @@ pub async fn geometric_match_folder(sub_matches: &ArgMatches) -> Result<(), CliE
     // The workbook is built from the same table as the CSV output, so the two
     // formats are always column-for-column consistent.
     if is_xls {
+        // Refuse an oversized workbook before building anything. The row count is just
+        // the number of (reference, candidate) pairs, which is known the moment
+        // matching finishes - so a report too tall for a worksheet fails here in
+        // milliseconds rather than after minutes of row building and cell formatting.
+        crate::xlsx_report::ensure_rows_fit(
+            all_matches
+                .iter()
+                .map(|response| response.matches.len())
+                .sum(),
+        )?;
+
         let (headers, rows) =
             build_geometric_match_table(&all_matches, with_metadata, &report_progress);
         let row_count = rows.len();
@@ -2667,4 +2684,135 @@ pub async fn text_match(sub_matches: &ArgMatches) -> Result<(), CliError> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn asset(path: &str, uuid: &str, metadata: &[(&str, &str)]) -> crate::model::AssetResponse {
+        crate::model::AssetResponse {
+            uuid: Uuid::parse_str(uuid).expect("valid uuid"),
+            tenant_id: Uuid::nil(),
+            path: path.to_string(),
+            folder_id: None,
+            asset_type: "asset".to_string(),
+            created_at: String::new(),
+            updated_at: String::new(),
+            state: "active".to_string(),
+            is_assembly: false,
+            metadata: metadata
+                .iter()
+                .map(|(k, v)| (k.to_string(), serde_json::Value::String(v.to_string())))
+                .collect::<HashMap<_, _>>(),
+            parent_folder_id: None,
+            owner_id: None,
+        }
+    }
+
+    fn geometric_match(
+        candidate: crate::model::AssetResponse,
+        percentage: f64,
+        url: Option<&str>,
+    ) -> crate::model::GeometricMatch {
+        crate::model::GeometricMatch {
+            asset: candidate,
+            match_percentage: percentage,
+            transformation: None,
+            comparison_url: url.map(|u| u.to_string()),
+        }
+    }
+
+    const REF_UUID: &str = "9ebd8801-388a-4fb8-a4fd-dd77d91e7cac";
+    const CAN_A_UUID: &str = "02c37ef8-caad-4a16-a992-6abbdda852f9";
+    const CAN_B_UUID: &str = "f16e93ca-bc0b-41c1-a98f-d1eeef01e4c1";
+
+    /// One response carrying two matches, to prove rows are produced per *match*
+    /// rather than per response.
+    fn sample() -> Vec<crate::model::EnhancedGeometricSearchResponse> {
+        vec![crate::model::EnhancedGeometricSearchResponse {
+            reference_asset: asset("/a/ref.prt", REF_UUID, &[("material", "steel")]),
+            matches: vec![
+                geometric_match(
+                    asset("/b/one.prt", CAN_A_UUID, &[("material", "alu")]),
+                    100.0,
+                    Some("https://example.com/compare?a=1"),
+                ),
+                geometric_match(
+                    asset("/c/two.prt", CAN_B_UUID, &[("finish", "anodized")]),
+                    81.5,
+                    None,
+                ),
+            ],
+        }]
+    }
+
+    #[test]
+    fn table_without_metadata_has_base_columns_and_url_last() {
+        let (headers, rows) =
+            build_geometric_match_table(&sample(), false, &ReportProgress::disabled());
+
+        assert_eq!(headers.last().map(String::as_str), Some("COMPARISON_URL"));
+        assert!(!headers.iter().any(|h| h.starts_with("REF_")));
+
+        assert_eq!(rows.len(), 2, "one row per match, not per response");
+        assert_eq!(
+            rows[0],
+            vec![
+                "/a/ref.prt".to_string(),
+                "/b/one.prt".to_string(),
+                "100".to_string(),
+                REF_UUID.to_string(),
+                CAN_A_UUID.to_string(),
+                "https://example.com/compare?a=1".to_string(),
+            ]
+        );
+        // A missing comparison URL becomes an empty cell, not a dropped column.
+        assert_eq!(rows[1].len(), headers.len());
+        assert_eq!(rows[1][2], "81.5");
+        assert_eq!(rows[1].last().map(String::as_str), Some(""));
+    }
+
+    #[test]
+    fn table_with_metadata_pairs_the_sorted_key_union() {
+        let (headers, rows) =
+            build_geometric_match_table(&sample(), true, &ReportProgress::disabled());
+
+        // Keys are the sorted union across both sides of every pair: finish, material.
+        let metadata_headers: Vec<&str> = headers
+            .iter()
+            .filter(|h| h.starts_with("REF_") || h.starts_with("CAN_"))
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            metadata_headers,
+            vec!["REF_FINISH", "CAN_FINISH", "REF_MATERIAL", "CAN_MATERIAL"]
+        );
+        assert_eq!(headers.last().map(String::as_str), Some("COMPARISON_URL"));
+
+        // Row 0: reference has material=steel and no finish; candidate has
+        // material=alu. Absent values are empty strings, keeping columns aligned.
+        let finish_ref = headers.iter().position(|h| h == "REF_FINISH").unwrap();
+        let material_ref = headers.iter().position(|h| h == "REF_MATERIAL").unwrap();
+        let material_can = headers.iter().position(|h| h == "CAN_MATERIAL").unwrap();
+        assert_eq!(rows[0][finish_ref], "");
+        assert_eq!(rows[0][material_ref], "steel");
+        assert_eq!(rows[0][material_can], "alu");
+
+        for row in &rows {
+            assert_eq!(
+                row.len(),
+                headers.len(),
+                "every row matches the header width"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_input_produces_headers_but_no_rows() {
+        let (headers, rows) = build_geometric_match_table(&[], false, &ReportProgress::disabled());
+        assert!(!headers.is_empty());
+        assert!(rows.is_empty());
+    }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -153,15 +153,18 @@ impl ReportProgress {
             return;
         }
         if let Some(bar) = &self.bar {
+            // Length and position first, style last. The steady tick redraws on its
+            // own thread, so flipping to the counter template before the length is
+            // set leaves a window where it renders a meaningless "0/0 (0%)".
+            bar.set_length(total as u64);
+            bar.set_position(0);
+            bar.set_message(message.into());
             bar.set_style(
                 indicatif::ProgressStyle::default_bar()
                     .template(REPORT_COUNTER_TEMPLATE)
                     .expect("valid counter template")
                     .progress_chars("#>-"),
             );
-            bar.set_message(message.into());
-            bar.set_length(total as u64);
-            bar.set_position(0);
         }
     }
 
@@ -172,6 +175,21 @@ impl ReportProgress {
             if should_report_row(index) {
                 bar.set_position(index as u64);
             }
+        }
+    }
+
+    /// Run `f` with the display temporarily cleared.
+    ///
+    /// Warnings and the bar both go to stderr, so printing one while the other is
+    /// drawing leaves the message shredded across a redraw. Use this for anything
+    /// that writes to stderr mid-phase.
+    pub fn suspend<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        match &self.bar {
+            Some(bar) => bar.suspend(f),
+            None => f(),
         }
     }
 

--- a/src/xlsx_report.rs
+++ b/src/xlsx_report.rs
@@ -74,6 +74,9 @@ pub enum XlsxReportError {
     /// An error occurred while building or saving the Excel workbook.
     #[error("failed to write Excel workbook: {0}")]
     Xlsx(#[from] XlsxError),
+    /// The report has more rows than a single worksheet can hold.
+    #[error("the report has {rows} rows, more than the {max} an Excel worksheet can hold - use '--format csv' for the complete report")]
+    TooManyRows { rows: usize, max: usize },
 }
 
 // ---------------------------------------------------------------------------
@@ -124,6 +127,13 @@ const MAX_URL_LEN: usize = 2080;
 
 /// Worksheet tab name.
 const SHEET_NAME: &str = "Match Report";
+
+/// Excel's hard limit on rows per worksheet (2^20). Not a guideline: a workbook
+/// claiming more rows than this is not a valid `.xlsx` and Excel will not open it.
+const EXCEL_MAX_ROWS: u32 = 1_048_576;
+
+/// The most data rows a sheet can hold, once the two header rows are subtracted.
+pub const MAX_DATA_ROWS: usize = (EXCEL_MAX_ROWS - DATA_START_ROW) as usize;
 
 /// The comparison state of a single `REF_`/`CAN_` cell pair within a row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -310,6 +320,30 @@ pub struct ConversionStats {
     pub missing: usize,
 }
 
+/// Rejects a report that is too tall for a single worksheet.
+///
+/// Refuses rather than truncating. A workbook silently missing a quarter of its rows
+/// looks complete to whoever opens it, and a warning on stderr scrolls away - a
+/// report that cannot be represented honestly should not be written at all.
+///
+/// Call this as early as the row count is known. That count is derivable from the
+/// match set before a single row is built, so an oversized report fails in seconds
+/// instead of after minutes of wasted matching and row building.
+/// [`write_match_report`] checks again, so the invariant holds however it is called.
+///
+/// The header-row arithmetic is the easy part to get wrong by one, and getting it
+/// wrong yields a workbook Excel refuses to open, so it is tested directly rather
+/// than by building a million-row fixture.
+pub fn ensure_rows_fit(rows: usize) -> Result<(), XlsxReportError> {
+    if rows > MAX_DATA_ROWS {
+        return Err(XlsxReportError::TooManyRows {
+            rows,
+            max: MAX_DATA_ROWS,
+        });
+    }
+    Ok(())
+}
+
 /// Ensures the output path carries the `.xlsx` extension (case-insensitive).
 ///
 /// Excel refuses to open a workbook whose extension and contents disagree, so a
@@ -359,6 +393,10 @@ pub fn write_match_report(
         ));
         report.sort_by_numeric_desc(column);
     }
+
+    // Backstop: callers are expected to have checked this before doing the work, but
+    // the invariant belongs here too - nothing below can represent an oversized sheet.
+    ensure_rows_fit(report.rows.len())?;
 
     write_workbook(&report, output, progress)
 }
@@ -765,6 +803,35 @@ mod tests {
             result,
             Err(XlsxReportError::MissingRequiredColumns(_))
         ));
+    }
+
+    #[test]
+    fn row_limit_accounts_for_the_two_header_rows() {
+        // A worksheet holds 2^20 rows total, and this report spends two of them on
+        // the group/label header band - so the data budget is two short of Excel's
+        // raw maximum. Off-by-one here produces a workbook Excel refuses to open.
+        assert_eq!(MAX_DATA_ROWS, 1_048_574);
+        assert_eq!(MAX_DATA_ROWS as u32 + DATA_START_ROW, EXCEL_MAX_ROWS);
+
+        assert!(ensure_rows_fit(0).is_ok());
+        assert!(ensure_rows_fit(MAX_DATA_ROWS - 1).is_ok());
+        assert!(
+            ensure_rows_fit(MAX_DATA_ROWS).is_ok(),
+            "an exactly-full sheet fits"
+        );
+        assert!(matches!(
+            ensure_rows_fit(MAX_DATA_ROWS + 1),
+            Err(XlsxReportError::TooManyRows { .. })
+        ));
+
+        // The run that prompted this: 1,293,068 rows from the etrage /Creo Files tree.
+        match ensure_rows_fit(1_293_068) {
+            Err(XlsxReportError::TooManyRows { rows, max }) => {
+                assert_eq!(rows, 1_293_068);
+                assert_eq!(max, MAX_DATA_ROWS);
+            }
+            other => panic!("expected TooManyRows, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Found by the progress reporting shipped in v1.14.0 — which is a decent argument that the reporting was worth building. On a real 1.29M-row report, the "Building rows" bar sat at **99% for nine seconds** before the next phase started.

### The stall

`build_geometric_match_table` collected a `Vec<GeometricMatchPair>` before building rows. Constructing it cloned each reference asset — metadata `HashMap` included — once per row, only ever to read a path and a UUID back out of it. That intermediate cost seconds to build and nine more to *drop* when the function returned, which is what the stall was.

Both the metadata-key pass and the row pass now iterate borrowed `(&reference_asset, &match)` tuples. Nothing is duplicated, so there is nothing to tear down.

`GeometricMatchPair::from_reference_and_match` is a plain field mapping (`asset` → `candidate_asset`, `match_percentage`, `comparison_url`), so reading those fields directly produces byte-identical rows.

### Oversized xls reports now fail fast

An Excel worksheet holds 1,048,576 rows and this report's header band takes two, leaving 1,048,574. The run above produced 1,293,068 — not representable. The check now runs immediately after matching, before a single row is built, so it fails in milliseconds instead of after minutes of row building and cell formatting.

Truncating to fit was considered and rejected: a workbook silently missing a quarter of its rows looks complete to whoever opens it, and a warning on stderr scrolls away.

### Two smaller fixes

- `ReportProgress::start_rows` sets the length before switching to the counter style, so the steady-tick thread can no longer catch it mid-transition and render `0/0 (0%)`. Observed once in 137 frames on the real run.
- `ReportProgress::suspend` clears the display around anything that writes to stderr, so a warning can't be shredded across a redraw.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, **246 tests** — all clean
- `build_geometric_match_table` had **no** unit coverage, which is what made this refactor riskier than it should have been. Three fixture tests now pin the column layout: one row per *match* rather than per response, `COMPARISON_URL` last with absent URLs as empty cells, and the sorted `REF_`/`CAN_` metadata union with missing values keeping rows header-width
- One test pins the header-row arithmetic (`MAX_DATA_ROWS == 1_048_574`, `MAX_DATA_ROWS + DATA_START_ROW == EXCEL_MAX_ROWS`) — an off-by-one there yields a workbook Excel refuses to open

### Not verified

Byte-identity against a live report is **still outstanding**. The confirming run failed for an unrelated reason: the auth token expired mid-run and 21,068 of 22,378 searches returned auth errors, so the two runs had different inputs and the comparison proved nothing. That failure is written up separately as #77 and #78.

The equivalence argument is structural — pure field mapping, one row per match in both versions — but it has not been demonstrated end-to-end on real data.

## Related

- #77 — folder match commands report success when most searches fail
- #78 — auth expiry mid-run fails every remaining search instead of aborting

🤖 Generated with [Claude Code](https://claude.com/claude-code)