### PR TITLE
Stop abandoning a metadata batch over one permission-denied asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A single permission-denied asset no longer aborts an entire metadata batch** ([#93](https://github.com/jchultarsky101/pcli2/issues/93)) - `asset metadata batch` stopped the whole run when any one asset returned a `403`, reporting it as an authentication failure and telling the user to re-authenticate a session that was never broken — so following the advice changed nothing and the next attempt failed identically. A `403` on one asset triggers a token renewal and a retry; when the retry fails for the same per-asset reason, the resulting error carries the text `403 Forbidden`, which the authentication check matched on. The decision to abandon a run now uses a narrower test that only fires when the credential renewal itself failed, so a per-asset permission denial (or a data-state conflict behind a `403`) is treated as a per-asset failure: counted, reported with permission-oriented guidance, and skipped under `--continue-on-error`. Asset lookups that fail for a reason other than the asset being absent are also no longer reported as "asset not found".
+
 ## [1.18.0] - 2026-07-31
 
 ### Fixed

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -503,7 +503,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                         asset
                     }
                     Err(e) => {
-                        if e.is_authentication_failure() {
+                        if e.is_credential_failure() {
                             auth_failure_occurred = true;
                             report(
                                 format!("Authentication failed while looking up asset '{}': {}", asset_display, e),
@@ -519,12 +519,30 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
 
                         failure_count += 1;
 
+                        // A lookup can fail for reasons other than the asset being
+                        // absent - most often a permission denial on an asset the
+                        // caller can see listed but not read. Calling that "not found"
+                        // sends the user hunting for a path problem that is not there.
+                        let missing = matches!(
+                            e,
+                            ApiError::NotFoundError(_)
+                                | ApiError::PathNotFound(_)
+                                | ApiError::InvalidAssetPath(_)
+                        );
+
                         // In continue-on-error mode a missing asset is expected and
                         // common, so emit a single concise line here and defer the
                         // detailed guidance to one summary at the end of the run.
                         if continue_on_error {
-                            skipped_missing += 1;
-                            warn(format!("Skipped '{}' — asset not found", asset_display));
+                            if missing {
+                                skipped_missing += 1;
+                                warn(format!("Skipped '{}' — asset not found", asset_display));
+                            } else {
+                                warn(format!(
+                                    "Skipped '{}' — lookup failed: {}",
+                                    asset_display, e
+                                ));
+                            }
                             continue;
                         }
 
@@ -544,10 +562,21 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                                 "Or re-run with --continue-on-error to skip unresolved paths",
                             ],
                         };
-                        report(
-                            format!("Asset not found: '{}'", asset_display),
-                            remediation_steps,
-                        );
+                        if missing {
+                            report(
+                                format!("Asset not found: '{}'", asset_display),
+                                remediation_steps,
+                            );
+                        } else {
+                            report(
+                                format!("Could not look up asset '{}': {}", asset_display, e),
+                                &[
+                                    "Check that you have permission to access this asset",
+                                    "Verify you're using the correct tenant for this asset",
+                                    "Or re-run with --continue-on-error to skip assets that cannot be read",
+                                ],
+                            );
+                        }
 
                         if let Some(pb) = progress_bar.as_ref() {
                             pb.finish_and_clear();
@@ -588,7 +617,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                 .delete_asset_metadata(&tenant.uuid.to_string(), &asset.uuid().to_string(), keys)
                 .await
             {
-                if e.is_authentication_failure() {
+                if e.is_credential_failure() {
                     auth_failure_occurred = true;
                     report(
                         format!(
@@ -647,7 +676,7 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                 )
                 .await
             {
-                if e.is_authentication_failure() {
+                if e.is_credential_failure() {
                     auth_failure_occurred = true;
                     report(
                         format!(

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -100,6 +100,28 @@ impl ApiError {
     /// True when the error indicates an authentication/authorization failure,
     /// including a 401/403 that persisted through the automatic token-refresh
     /// retry (which surfaces as `RetryFailed` rather than `AuthError`).
+    /// True when the credentials themselves are unusable, so no later request can
+    /// succeed.
+    ///
+    /// Narrower than [`Self::is_authentication_failure`] on purpose, and the two are
+    /// not interchangeable:
+    ///
+    /// - Use *this* to decide whether to abandon an operation. These three are raised
+    ///   when the token *renewal* failed, which is about the session rather than any
+    ///   one request.
+    /// - Use `is_authentication_failure` to decide whether an error message should
+    ///   mention authentication. It also matches a `RetryFailed` whose text contains a
+    ///   401/403, which is a useful hint but a poor basis for giving up: a retried
+    ///   request can fail 403 because the caller genuinely lacks permission for that
+    ///   one asset, or 409 because that one asset is not indexed. Neither says
+    ///   anything about the next asset.
+    pub fn is_credential_failure(&self) -> bool {
+        matches!(
+            self,
+            ApiError::AuthError(_) | ApiError::InvalidToken | ApiError::MissingCredentials
+        )
+    }
+
     pub fn is_authentication_failure(&self) -> bool {
         match self {
             ApiError::AuthError(_) | ApiError::InvalidToken | ApiError::MissingCredentials => true,
@@ -112,6 +134,58 @@ impl ApiError {
             }
             _ => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod credential_failure_tests {
+    use super::*;
+
+    #[test]
+    fn only_renewal_failures_count_as_credential_failures() {
+        // These are raised when the token renewal itself failed, so nothing later can
+        // succeed - the only safe basis for abandoning an operation.
+        assert!(ApiError::AuthError("renewal failed".into()).is_credential_failure());
+        assert!(ApiError::InvalidToken.is_credential_failure());
+        assert!(ApiError::MissingCredentials.is_credential_failure());
+    }
+
+    #[test]
+    fn a_per_asset_403_is_not_a_credential_failure() {
+        // The bug this exists for: one asset the caller lacks permission for produced
+        // a RetryFailed carrying "403 Forbidden", which the looser predicate matched -
+        // abandoning the whole batch and telling the user to re-authenticate a session
+        // that was working.
+        let per_asset_403 = ApiError::RetryFailed(
+            "Original error: 403 Forbidden, Retry failed with status: 403 Forbidden".into(),
+        );
+        assert!(
+            !per_asset_403.is_credential_failure(),
+            "one forbidden asset must not abandon the run"
+        );
+        assert!(
+            per_asset_403.is_authentication_failure(),
+            "but it is still worth mentioning auth in the message"
+        );
+    }
+
+    #[test]
+    fn a_data_state_conflict_behind_a_403_is_not_a_credential_failure() {
+        // Observed on a live tenant: a 403 triggers a renewal, the retry succeeds in
+        // reaching the server and comes back 409 because that asset is not indexed.
+        let observed = ApiError::RetryFailed(
+            "Original error: 403 Forbidden, Retry failed with status: 409 Conflict \
+             and body: {\"message\":\"Asset not indexed yet\"}"
+                .into(),
+        );
+        assert!(!observed.is_credential_failure());
+    }
+
+    #[test]
+    fn ordinary_errors_are_neither() {
+        let conflict = ApiError::ConflictError("Asset not indexed yet".into());
+        assert!(!conflict.is_credential_failure());
+        assert!(!conflict.is_authentication_failure());
     }
 }
 


### PR DESCRIPTION
Closes #93.

## The problem

A `403` on a single asset aborted the whole `asset metadata batch` run and reported it as an authentication failure — telling the user to re-authenticate a session that was working. Following that advice changed nothing, so the next attempt failed identically.

`execute_request` treats a `403` as possibly-a-stale-token: it renews and retries. When the retry fails for the same per-asset reason, the error becomes `RetryFailed` carrying the text `403 Forbidden`, and `is_authentication_failure` matches that by substring:

```rust
ApiError::RetryFailed(msg) => {
    let msg = msg.to_lowercase();
    msg.contains("401") || msg.contains("403")
        || msg.contains("unauthorized") || msg.contains("forbidden")
}
```

That predicate is fine for deciding whether a message should *mention* authentication, where a loose match costs nothing. It is too loose for deciding whether to throw away the rest of the work.

The same shape occurs with data-state conflicts. Observed on a live tenant:

```
Original error: 403 Forbidden, Retry failed with status: 409 Conflict
and body: {"message":"Asset not indexed yet"}
```

## The change

Adds `ApiError::is_credential_failure()`, which fires only for `AuthError`, `InvalidToken` and `MissingCredentials` — the errors raised when the *renewal itself* failed, and so the only ones that say anything about requests other than the one that produced them. The three abort sites in `create.rs` use it; `is_authentication_failure` is untouched for message shaping.

Everything else now falls through to the existing per-asset handling, which already reports permission-oriented remediation ("Check that you have sufficient permissions to modify this asset") and skips under `--continue-on-error`.

**One thing that needed fixing alongside it:** the asset *lookup* path assumed any non-auth error meant the asset was absent, so routing `403`s into it would have swapped one misleading message for another. It now distinguishes a genuine not-found from any other lookup failure and reports the latter with its own text and permission-oriented guidance.

## Deliberately not done

This does **not** import the consecutive-failure counting used by the concurrent match commands (#78). That exists because renewal there is noisy enough that a single failure carries little signal — each task held its own client clone. This batch is sequential over a single shared client, so a renewal persists to the next iteration, and stopping promptly on a genuine credential failure is more defensible for a *mutating* operation than for a read-only one. Only the false positive needed fixing.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, **274 tests** — all clean
- Four new tests: renewal failures are credential failures; a per-asset `403` is not (but *is* still an authentication failure for messaging); the observed `403`-then-`409` shape is not; ordinary errors are neither

Not exercised against a live tenant — reproducing it needs an asset the caller can list but not write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)