### PR TITLE
Report a role problem as a role problem, not an auth failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A batch that fails because the account lacks the Author role now says so** - Physna has no per-asset permissions: an account is an Author, who may write any asset, or a Viewer, who may write none. A Viewer running `asset metadata batch` therefore fails on every write, but the run reported an authentication failure and told the user to re-authenticate — a session that was working perfectly. `pcli2` now distinguishes *authenticated but not permitted* from *credentials not working*: a `403` that survives a token renewal is reported as a role problem, with guidance to ask a tenant administrator for the Author role, and stops the run immediately rather than repeating the same failure for every remaining asset. A `401` that survives renewal still means the credentials themselves are the problem and still asks the user to log in again.
+
 ## [1.18.1] - 2026-07-31
 
 ### Fixed

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -435,6 +435,10 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
     let mut failure_count = 0;
     let mut skipped_missing = 0;
     let mut auth_failure_occurred = false;
+    // Tracked separately from a credential failure: the run stops for both, but
+    // "re-authenticate" is useless advice when the session is fine and the account
+    // simply may not write.
+    let mut authorization_failure_occurred = false;
 
     // Progress bar drawn on stderr. Unlike a hand-rolled "\r"-prefixed line, it
     // redraws cleanly instead of leaving stale characters behind when the next
@@ -617,6 +621,28 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                 .delete_asset_metadata(&tenant.uuid.to_string(), &asset.uuid().to_string(), keys)
                 .await
             {
+                // Authenticated, but not permitted. Physna has no per-asset
+                // permissions - an account may write every asset or none - so this
+                // will fail identically for everything left in the batch. Stopping
+                // beats reporting the same thing N times, and the useful advice is
+                // about the account's role, not about logging in again.
+                if e.is_authorization_failure() {
+                    authorization_failure_occurred = true;
+                    report(
+                        format!(
+                            "Not permitted to modify assets in this tenant (while deleting metadata for '{}'): {}",
+                            asset_display, e
+                        ),
+                        &[
+                            "Writing metadata requires the Author role; a Viewer account can only read",
+                            "Ask a tenant administrator to grant your account the Author role",
+                            "Or verify you are targeting the intended tenant with --tenant",
+                        ],
+                    );
+                    failure_count += 1;
+                    break;
+                }
+
                 if e.is_credential_failure() {
                     auth_failure_occurred = true;
                     report(
@@ -676,6 +702,28 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                 )
                 .await
             {
+                // Authenticated, but not permitted. Physna has no per-asset
+                // permissions - an account may write every asset or none - so this
+                // will fail identically for everything left in the batch. Stopping
+                // beats reporting the same thing N times, and the useful advice is
+                // about the account's role, not about logging in again.
+                if e.is_authorization_failure() {
+                    authorization_failure_occurred = true;
+                    report(
+                        format!(
+                            "Not permitted to modify assets in this tenant (while updating metadata for '{}'): {}",
+                            asset_display, e
+                        ),
+                        &[
+                            "Writing metadata requires the Author role; a Viewer account can only read",
+                            "Ask a tenant administrator to grant your account the Author role",
+                            "Or verify you are targeting the intended tenant with --tenant",
+                        ],
+                    );
+                    failure_count += 1;
+                    break;
+                }
+
                 if e.is_credential_failure() {
                     auth_failure_occurred = true;
                     report(
@@ -769,6 +817,12 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
         eprintln!("  2. You are targeting the correct tenant");
         eprintln!("  3. The assets have not been deleted, and paths match (e.g., leading slash)");
         eprintln!("  List existing paths with 'pcli2 asset list --folder-path /' to compare.");
+    }
+
+    if authorization_failure_occurred {
+        return Err(CliError::SecurityError(
+            "Batch operation stopped: this account is not permitted to modify assets in this tenant. Writing metadata requires the Author role.".to_string(),
+        ));
     }
 
     if auth_failure_occurred {

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -137,26 +137,62 @@ impl ApiError {
         }
     }
 
-    /// Whether the *retry* in a `RetryFailed` message was itself rejected as
-    /// unauthorized, ignoring the original status that triggered the retry.
-    fn retry_status_is_unauthorized(message: &str) -> bool {
+    /// The status the *retry* came back with, lowercased, excluding the response body.
+    ///
+    /// `None` when the message does not have the expected shape, which callers should
+    /// read conservatively - anything reaching `RetryFailed` got there through the
+    /// 401/403 path to begin with.
+    fn retry_status(message: &str) -> Option<String> {
         const RETRY_MARKER: &str = "retry failed with status:";
         let lowered = message.to_lowercase();
-        let Some(after_retry) = lowered.split_once(RETRY_MARKER).map(|(_, rest)| rest) else {
-            // An unrecognized shape: fall back to treating it as authentication-related,
-            // which is the conservative reading for a message that got here through the
-            // 401/403 path in the first place.
-            return true;
-        };
-        // Only the status itself, not the response body - a body can quote anything.
-        let status = after_retry
-            .split(" and body:")
-            .next()
-            .unwrap_or(after_retry);
-        status.contains("401")
-            || status.contains("403")
-            || status.contains("unauthorized")
-            || status.contains("forbidden")
+        let after_retry = lowered.split_once(RETRY_MARKER).map(|(_, rest)| rest)?;
+        // Only the status itself - a response body can quote anything.
+        Some(
+            after_retry
+                .split(" and body:")
+                .next()
+                .unwrap_or(after_retry)
+                .to_string(),
+        )
+    }
+
+    /// Whether the retry was itself rejected as unauthorized or forbidden.
+    fn retry_status_is_unauthorized(message: &str) -> bool {
+        match Self::retry_status(message) {
+            Some(status) => {
+                status.contains("401")
+                    || status.contains("403")
+                    || status.contains("unauthorized")
+                    || status.contains("forbidden")
+            }
+            None => true,
+        }
+    }
+
+    /// True when the request was authenticated but not *permitted*.
+    ///
+    /// Physna has no per-asset permissions: an account is an Author, who may write any
+    /// asset, or a Viewer, who may write none. So a 403 that survives a token renewal
+    /// says something about the account rather than the asset, and every subsequent
+    /// write will fail identically - which makes it worth stopping on, and worth
+    /// reporting as a role problem rather than a credential one.
+    ///
+    /// Deliberately excludes a retry that came back 401. That is the token being
+    /// rejected outright, which is [`Self::is_credential_failure`] territory and calls
+    /// for logging in again rather than for a conversation about roles.
+    pub fn is_authorization_failure(&self) -> bool {
+        match self {
+            ApiError::RetryFailed(msg) => match Self::retry_status(msg) {
+                Some(status) => {
+                    (status.contains("403") || status.contains("forbidden"))
+                        && !status.contains("401")
+                        && !status.contains("unauthorized")
+                }
+                // An unrecognized shape says nothing specific about authorization.
+                None => false,
+            },
+            _ => false,
+        }
     }
 }
 
@@ -227,6 +263,60 @@ mod credential_failure_tests {
         // If the message shape ever changes, fall back to the conservative reading -
         // it reached `RetryFailed` through the 401/403 path to begin with.
         assert!(ApiError::RetryFailed("something else entirely".into()).is_authentication_failure());
+    }
+
+    #[test]
+    fn a_persistent_403_is_an_authorization_failure_not_a_credential_one() {
+        // Physna has no per-asset permissions, so a 403 that survives a renewal is
+        // about the account: a Viewer trying to write. It will fail identically for
+        // every remaining asset, and "re-authenticate" is useless advice.
+        let forbidden = ApiError::RetryFailed(
+            "Original error: 403 Forbidden, Retry failed with status: 403 Forbidden and body: {}"
+                .into(),
+        );
+        assert!(forbidden.is_authorization_failure());
+        assert!(
+            !forbidden.is_credential_failure(),
+            "the credentials worked - the account is not allowed"
+        );
+        assert!(
+            forbidden.is_authentication_failure(),
+            "still auth-adjacent for message shaping"
+        );
+    }
+
+    #[test]
+    fn a_persistent_401_is_a_credential_problem_not_an_authorization_one() {
+        // The token was rejected outright even after renewal. That calls for logging
+        // in again, not for a conversation about roles.
+        let unauthorized = ApiError::RetryFailed(
+            "Original error: 401 Unauthorized, Retry failed with status: 401 Unauthorized and body: {}"
+                .into(),
+        );
+        assert!(!unauthorized.is_authorization_failure());
+        assert!(unauthorized.is_authentication_failure());
+    }
+
+    #[test]
+    fn a_retry_that_left_the_403_behind_is_not_an_authorization_failure() {
+        // The 403 was a stale token; the renewal fixed it and the retry reached the
+        // server, which refused for an unrelated reason. Nothing to do with roles.
+        let not_indexed = ApiError::RetryFailed(
+            "Original error: 403 Forbidden, Retry failed with status: 409 Conflict \
+             and body: {\"message\":\"Asset not indexed yet\"}"
+                .into(),
+        );
+        assert!(!not_indexed.is_authorization_failure());
+        assert!(!not_indexed.is_credential_failure());
+        assert!(!not_indexed.is_authentication_failure());
+    }
+
+    #[test]
+    fn a_renewal_failure_is_not_an_authorization_failure() {
+        // Never route a dead credential to "ask for the Author role".
+        assert!(!ApiError::AuthError("renewal failed".into()).is_authorization_failure());
+        assert!(!ApiError::InvalidToken.is_authorization_failure());
+        assert!(!ApiError::MissingCredentials.is_authorization_failure());
     }
 
     #[test]


### PR DESCRIPTION
## The problem

Physna has no per-asset permissions: an account is an **Author** (may write any asset) or a **Viewer** (may write none). A Viewer running `asset metadata batch` therefore fails on *every* write — but the run reported an authentication failure and told the user to re-authenticate a session that was working perfectly. Following that advice changed nothing.

## The change

Adds `ApiError::is_authorization_failure()`, which fires when a `403` **survives a token renewal**. The renewal having worked is what makes it meaningful: the credentials are fine and the request was still refused, which given the role model is a property of the account rather than of the asset.

That same distinction decides whether to keep going:

| Retry outcome | Meaning | Behaviour |
|---|---|---|
| `403` → `409` | stale token, renewal worked, asset simply not indexed | per-asset — batch continues |
| `403` → `403` | authenticated, not permitted — account lacks Author | **stops**, asks for the Author role |
| `403` → `401` | token rejected outright | **stops**, asks to log in again |

Stopping on a persistent `403` matters because without per-asset permissions it will fail identically for everything left in the batch — repeating the same message N times helps nobody.

The closing error message is split too, so the two cases no longer share remediation that is only correct for one of them.

**The asset lookup path is deliberately untouched** — a Viewer can read.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, **280 tests** — all clean
- Four new tests covering each corner: a persistent `403` is an authorization failure but *not* a credential one; a persistent `401` is the reverse; a `403` whose retry left it behind is neither; and a renewal failure never routes to "ask for the Author role"

Not exercised against a live tenant — confirming it needs a Viewer-role account.

## Context

Follows #93 and PR #95. This is the remaining piece I'd flagged there as known-but-unaddressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)