### PR TITLE
Fail loudly when --recursive cannot enumerate subfolders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.3] - 2026-07-31
+
+### Fixed
+- **`--recursive` no longer degrades silently into a non-recursive scan** - When the folder hierarchy could not be loaded, a recursive folder match fell back to listing only the assets sitting directly in the folder. The warning that was supposed to explain it went to stderr underneath the `--progress` spinner, which redraws every 100ms and painted straight over it — so the run looked like a success and simply reported far too few assets. Reported from the field as "--recursive is not working": a folder holding 22,378 assets across 511 subfolders reported **1**, the count of assets directly inside it. A recursive scan that cannot enumerate subfolders now fails with an explanation and a suggestion to run `pcli2 cache clear`, rather than quietly answering a different question. The same applies when the folder resolves against the API but is missing from the cached hierarchy, which previously produced a silent empty result. Scan errors also clear the spinner before printing, so the message survives.
+- **`--continue-on-error` now takes precedence over the permission stop** - A `403` that survives a token renewal stops a metadata batch, since without per-asset permissions every remaining write would fail the same way. `--continue-on-error` means what it says, so it now wins: the account-level explanation is given once and the run continues, with the usual terse per-asset skip lines.
+
 ## [1.18.2] - 2026-07-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "pcli2"
-version = "1.18.2"
+version = "1.18.3"
 dependencies = [
  "assert_cmd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcli2"
-version = "1.18.2"
+version = "1.18.3"
 edition = "2021"
 authors = ["Julian Chultarsky <jchultarsky@physna.com>"]
 description = "CLI client for the Physna public API - Advanced 3D Geometry Search and Analysis"

--- a/src/actions/assets/create.rs
+++ b/src/actions/assets/create.rs
@@ -439,6 +439,9 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
     // "re-authenticate" is useless advice when the session is fine and the account
     // simply may not write.
     let mut authorization_failure_occurred = false;
+    // Under --continue-on-error the account-level explanation is given once; the
+    // per-asset lines after it stay terse.
+    let mut authorization_notice_shown = false;
 
     // Progress bar drawn on stderr. Unlike a hand-rolled "\r"-prefixed line, it
     // redraws cleanly instead of leaving stale characters behind when the next
@@ -627,6 +630,25 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                 // beats reporting the same thing N times, and the useful advice is
                 // about the account's role, not about logging in again.
                 if e.is_authorization_failure() {
+                    failure_count += 1;
+
+                    // --continue-on-error means what it says, so it wins here too.
+                    // Every remaining write will fail identically - there are no
+                    // per-asset permissions - so explain that once and then keep the
+                    // per-asset lines terse, the same shape as any other skip.
+                    if continue_on_error {
+                        if !authorization_notice_shown {
+                            authorization_notice_shown = true;
+                            warn(
+                                "Not permitted to modify assets in this tenant — writing metadata requires the Author role. \
+                                 Continuing as requested; every remaining write will fail the same way."
+                                    .to_string(),
+                            );
+                        }
+                        warn(format!("Skipped '{}' — not permitted", asset_display));
+                        continue;
+                    }
+
                     authorization_failure_occurred = true;
                     report(
                         format!(
@@ -637,9 +659,9 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                             "Writing metadata requires the Author role; a Viewer account can only read",
                             "Ask a tenant administrator to grant your account the Author role",
                             "Or verify you are targeting the intended tenant with --tenant",
+                            "Or re-run with --continue-on-error to attempt every asset anyway",
                         ],
                     );
-                    failure_count += 1;
                     break;
                 }
 
@@ -708,6 +730,25 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                 // beats reporting the same thing N times, and the useful advice is
                 // about the account's role, not about logging in again.
                 if e.is_authorization_failure() {
+                    failure_count += 1;
+
+                    // --continue-on-error means what it says, so it wins here too.
+                    // Every remaining write will fail identically - there are no
+                    // per-asset permissions - so explain that once and then keep the
+                    // per-asset lines terse, the same shape as any other skip.
+                    if continue_on_error {
+                        if !authorization_notice_shown {
+                            authorization_notice_shown = true;
+                            warn(
+                                "Not permitted to modify assets in this tenant — writing metadata requires the Author role. \
+                                 Continuing as requested; every remaining write will fail the same way."
+                                    .to_string(),
+                            );
+                        }
+                        warn(format!("Skipped '{}' — not permitted", asset_display));
+                        continue;
+                    }
+
                     authorization_failure_occurred = true;
                     report(
                         format!(
@@ -718,9 +759,9 @@ pub async fn create_asset_metadata_batch(sub_matches: &ArgMatches) -> Result<(),
                             "Writing metadata requires the Author role; a Viewer account can only read",
                             "Ask a tenant administrator to grant your account the Author role",
                             "Or verify you are targeting the intended tenant with --tenant",
+                            "Or re-run with --continue-on-error to attempt every asset anyway",
                         ],
                     );
-                    failure_count += 1;
                     break;
                 }
 

--- a/src/actions/assets/match_ops.rs
+++ b/src/actions/assets/match_ops.rs
@@ -347,19 +347,30 @@ async fn collect_assets_in_folders(
         let assets_response = if recursive {
             let path_label = folder_path.clone();
             let progress = scan_progress.as_ref();
-            api.list_assets_by_parent_folder_path_recursive(
-                tenant_uuid,
-                folder_path.as_str(),
-                |scanned, total, assets| {
-                    if let Some(progress) = progress {
-                        progress.set_message(format!(
-                            "Scanning {}: {}/{} folders, {} assets found",
-                            path_label, scanned, total, assets
-                        ));
-                    }
-                },
-            )
-            .await?
+            let result = api
+                .list_assets_by_parent_folder_path_recursive(
+                    tenant_uuid,
+                    folder_path.as_str(),
+                    |scanned, total, assets| {
+                        if let Some(progress) = progress {
+                            progress.set_message(format!(
+                                "Scanning {}: {}/{} folders, {} assets found",
+                                path_label, scanned, total, assets
+                            ));
+                        }
+                    },
+                )
+                .await;
+
+            // Clear the spinner before any error reaches the terminal. It redraws
+            // every 100ms, so a message written underneath it is wiped on the next
+            // tick - which is exactly how the old silent fallback stayed invisible.
+            if result.is_err() {
+                if let Some(progress) = scan_progress.as_ref() {
+                    progress.finish_and_clear();
+                }
+            }
+            result?
         } else {
             api.list_assets_by_parent_folder_path(tenant_uuid, folder_path.as_str())
                 .await?

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -157,3 +157,115 @@ pub fn create_full_command() -> Command {
         .subcommand(man::man_command())
         .subcommand(cache::cache_command())
 }
+
+#[cfg(test)]
+mod recursive_flag_tests {
+    use super::*;
+
+    /// Parse an argument vector exactly as the binary would.
+    fn parse(args: &[&str]) -> Result<ArgMatches, clap::Error> {
+        create_full_command().try_get_matches_from(args)
+    }
+
+    #[test]
+    fn recursive_is_recognized_when_it_follows_the_folder_path() {
+        // `--folder-path` takes one-or-more values, so the question is whether a flag
+        // written immediately after it gets swallowed as another path. Reported from
+        // the field as "--recursive is not recognized".
+        let matches = parse(&[
+            "pcli2",
+            "folder",
+            "geometric-match",
+            "--threshold",
+            "100.00",
+            "--metadata",
+            "--pretty",
+            "--concurrent",
+            "10",
+            "--progress",
+            "--folder-path",
+            "/Creo Files",
+            "--recursive",
+        ])
+        .expect("the documented invocation must parse");
+
+        let sub = matches
+            .subcommand_matches("folder")
+            .and_then(|m| m.subcommand_matches("geometric-match"))
+            .expect("geometric-match");
+
+        let paths: Vec<&String> = sub
+            .get_many::<String>(crate::commands::params::PARAMETER_FOLDER_PATH)
+            .expect("folder-path")
+            .collect();
+        assert_eq!(
+            paths,
+            vec!["/Creo Files"],
+            "the flag must not become a path"
+        );
+        assert!(
+            sub.get_flag(crate::commands::params::PARAMETER_RECURSIVE),
+            "--recursive must be set"
+        );
+    }
+
+    #[test]
+    fn recursive_is_recognized_before_the_folder_path_too() {
+        let matches = parse(&[
+            "pcli2",
+            "folder",
+            "geometric-match",
+            "--recursive",
+            "--folder-path",
+            "/Creo Files",
+        ])
+        .expect("must parse");
+        let sub = matches
+            .subcommand_matches("folder")
+            .and_then(|m| m.subcommand_matches("geometric-match"))
+            .unwrap();
+        assert!(sub.get_flag(crate::commands::params::PARAMETER_RECURSIVE));
+    }
+
+    #[test]
+    fn the_short_form_works_too() {
+        let matches = parse(&[
+            "pcli2",
+            "folder",
+            "geometric-match",
+            "--folder-path",
+            "/Creo Files",
+            "-R",
+        ])
+        .expect("must parse");
+        let sub = matches
+            .subcommand_matches("folder")
+            .and_then(|m| m.subcommand_matches("geometric-match"))
+            .unwrap();
+        assert!(sub.get_flag(crate::commands::params::PARAMETER_RECURSIVE));
+    }
+
+    #[test]
+    fn part_and_visual_match_accept_it_as_well() {
+        for command in ["part-match", "visual-match"] {
+            let matches = parse(&[
+                "pcli2",
+                "folder",
+                command,
+                "--folder-path",
+                "/Creo Files",
+                "--recursive",
+            ])
+            .unwrap_or_else(|e| panic!("{} must accept --recursive: {}", command, e));
+            let sub = matches
+                .subcommand_matches("folder")
+                .and_then(|m| m.subcommand_matches(command))
+                .unwrap();
+            assert!(
+                sub.get_flag(crate::commands::params::PARAMETER_RECURSIVE),
+                "{}",
+                command
+            );
+        }
+    }
+}

--- a/src/folder_hierarchy.rs
+++ b/src/folder_hierarchy.rs
@@ -696,6 +696,17 @@ mod tests {
     }
 
     #[test]
+    fn an_unknown_folder_has_an_empty_subtree() {
+        // The signal a recursive scan uses to detect a stale cache: the path resolved
+        // against the API, but the folder is absent from the cached hierarchy, so its
+        // descendants cannot be enumerated. Returning empty here must be treated as an
+        // error by the caller rather than as "this folder has no assets" - a folder
+        // holding 22,378 assets across 511 subfolders once reported 1.
+        let hierarchy = FolderHierarchy::default();
+        assert!(hierarchy.subtree_uuids(&Uuid::new_v4()).is_empty());
+    }
+
+    #[test]
     fn subtree_uuids_includes_the_folder_and_every_descendant() {
         // Regression: folder match reports listed only a folder's direct assets, so a
         // container folder such as "Creo Files" - which holds nothing but subfolders -

--- a/src/physna_v3.rs
+++ b/src/physna_v3.rs
@@ -14,7 +14,7 @@ use reqwest;
 use serde_json;
 use serde_urlencoded;
 use std::path::Path;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, trace};
 use uuid::Uuid;
 
 /// Error emitted by the Physna V3 Api
@@ -77,6 +77,15 @@ pub enum ApiError {
     /// Not found error with a descriptive message
     #[error("Not found error: {0}")]
     NotFoundError(String),
+
+    /// The folder hierarchy needed to enumerate subfolders could not be obtained, so a
+    /// recursive listing cannot be performed.
+    #[error(
+        "could not load the folder hierarchy needed by --recursive: {0}. \
+         Without it only the assets directly in the folder can be listed, which is not \
+         what was asked for. Try 'pcli2 cache clear' and run the command again."
+    )]
+    FolderHierarchyUnavailable(String),
 
     #[error(
         "Attempting to delete folder that is not empty. If you are sure, use the --force flag"
@@ -2075,29 +2084,35 @@ impl PhysnaApiClient {
             .resolve_folder_uuid_by_path(tenant_uuid, parent_folder_path)
             .await?;
 
-        // Without the hierarchy there is no way to enumerate descendants, so fall back
-        // to the direct-children behaviour rather than failing the whole report.
-        let hierarchy = match crate::folder_cache::FolderCache::get_or_fetch(self, tenant_uuid)
+        // Without the hierarchy there is no way to enumerate descendants. This used to
+        // fall back to listing only the folder's direct children, which is a silent
+        // lie: the caller asked for a recursive scan and got a non-recursive one, with
+        // the explanatory warning drawn over by the scan spinner on the very next
+        // redraw. A folder holding one asset and five hundred subfolders reported one
+        // asset and looked like it had worked. Fail instead.
+        let hierarchy = crate::folder_cache::FolderCache::get_or_fetch(self, tenant_uuid)
             .await
-        {
-            Ok(hierarchy) => Some(hierarchy),
-            Err(e) => {
-                warn!(
-                    "Could not load the folder hierarchy ({}); listing only the assets directly in '{}'",
-                    e, parent_folder_path
-                );
-                None
-            }
-        };
+            .map_err(|e| ApiError::FolderHierarchyUnavailable(e.to_string()))?;
 
-        let (subtree_uuids, include_root_level) = match (hierarchy, parent_folder_uuid.as_ref()) {
+        let (subtree_uuids, include_root_level) = match parent_folder_uuid.as_ref() {
             // A resolved folder: that folder plus all of its descendants.
-            (Some(hierarchy), Some(uuid)) => (hierarchy.subtree_uuids(uuid), false),
+            Some(uuid) => {
+                let subtree = hierarchy.subtree_uuids(uuid);
+                // The path resolved against the API but the folder is absent from the
+                // cached hierarchy, so its descendants cannot be enumerated - a stale
+                // cache, most often a folder created since it was written. Same
+                // reasoning as above: better an error than a quietly partial report.
+                if subtree.is_empty() {
+                    return Err(ApiError::FolderHierarchyUnavailable(format!(
+                        "'{}' is not present in the cached folder hierarchy",
+                        parent_folder_path
+                    )));
+                }
+                (subtree, false)
+            }
             // The tenant root has no UUID of its own; it covers every folder, and
             // assets can also live at root level with no parent folder at all.
-            (Some(hierarchy), None) => (hierarchy.all_subtree_uuids(), true),
-            (None, Some(uuid)) => (vec![*uuid], false),
-            (None, None) => (Vec::new(), true),
+            None => (hierarchy.all_subtree_uuids(), true),
         };
 
         let mut assets = AssetList::empty();


### PR DESCRIPTION
Reported from the field as *"--recursive is not working"*.

## What was happening

A folder holding **22,378 assets across 511 subfolders reported 1** — the number of assets sitting directly inside it — with no error and an apparently successful run.

When the folder hierarchy could not be loaded, the recursive listing fell back to the folder's direct children:

```rust
Err(e) => {
    warn!("Could not load the folder hierarchy ({}); listing only the assets directly in '{}'", e, parent_folder_path);
    None
}
…
(None, Some(uuid)) => (vec![*uuid], false),   // direct children only
```

There *was* a warning — but it goes to stderr underneath the `--progress` spinner, which redraws every 100ms and paints over it on the next tick. So the caller asked for a recursive scan, silently got a non-recursive one, and had no way to tell.

Same failure mode as #77, and it gets the same treatment.

## The change

- **A recursive scan that cannot enumerate subfolders is now an error**, naming the cause and suggesting `pcli2 cache clear`, rather than quietly answering a different question.
- **The stale-cache case is covered too.** When the path resolves against the API but the folder is absent from the cached hierarchy, `subtree_uuids` returns empty — previously a silent zero-asset report. It now errors and names the folder.
- **Scan errors clear the spinner before propagating**, so the message survives. That omission is why this stayed invisible.

## Also included

The change making `--continue-on-error` take precedence over the authorization stop added in 1.18.2 — the flag means what it says, so the account-level explanation is given once and the run continues with the usual terse per-asset skip lines.

Plus four parse tests covering `--recursive` in every position (after `--folder-path`, before it, `-R`, and on part/visual-match). The real risk there was `--folder-path`'s `num_args(1..)` swallowing a following flag; it doesn't, and that is now pinned.

## Test plan

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, **285 tests** — all clean
- Verified against the reporting tenant: `--recursive` scans 511 folders and finds 22,378 assets; the same folder without it finds 1 — exactly what the field report showed
- Live recursive smoke test on a subtree after the change: still returns matches from nested folders

## Not fixed here

This makes the failure *visible*; it does not explain why the hierarchy fails to load on the reporting user's machine. Their `--verbose` output will show the underlying error, which this change stops swallowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)