### PR TITLE
ci: run the Rust checks on develop, not just main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,15 @@
 name: Rust
 
+# `develop` is included alongside `main` because GitFlow makes it the branch
+# feature work actually lands on: a feature PR targets `develop`, and `main`
+# only sees an already-merged release PR. Filtering to `main` alone meant the
+# fmt/clippy/test jobs first ran on a change long after it was merged, so the
+# feature PR itself was gated by nothing but the cargo-dist `plan` check.
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Problem

`rust.yml` — the workflow holding `fmt`, `clippy`, and `build-and-test` — filtered both its triggers to `main`. Under GitFlow that is the one branch feature work never targets directly: a feature PR goes into `develop`, and `main` only ever sees an already-merged release PR.

The effect is that a feature PR ran **no** compile, lint, or test in CI. #105 is the illustration — it went green on GitGuardian and the cargo-dist `plan` check alone, with every build job skipped. Its correctness rested entirely on local verification. The first CI run of that code will be the `develop` → `main` release PR, long after merge.

## Change

Adds `develop` to both triggers, mirroring `main`:

- **`pull_request`** — the one that matters; gates feature PRs before they land.
- **`push`** — catches a merge into `develop` that breaks something no individual PR did (semantic conflict between two PRs merged in sequence).

The `coverage` job is unaffected: it gates on `if: github.ref == 'refs/heads/main'` and stays main-only.

## Verification

This PR targets `develop`, so it exercises the new filter on itself — `fmt`, `clippy`, and `build-and-test` across Linux/macOS/Windows should now appear on this PR where they did not on #105. That is the check to look for when reviewing.

## Cost

Merges into `develop` now cost a 3-OS build matrix they previously skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)