### PR TITLE
ci: drop develop from the push trigger, keep it on pull_request

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,13 +1,17 @@
 name: Rust
 
-# `develop` is included alongside `main` because GitFlow makes it the branch
-# feature work actually lands on: a feature PR targets `develop`, and `main`
-# only sees an already-merged release PR. Filtering to `main` alone meant the
-# fmt/clippy/test jobs first ran on a change long after it was merged, so the
-# feature PR itself was gated by nothing but the cargo-dist `plan` check.
+# `develop` is a `pull_request` target but deliberately not a `push` one.
+# GitFlow makes it the branch feature work actually lands on - a feature PR
+# targets `develop`, and `main` only sees an already-merged release PR - so
+# gating those PRs is what stops a change reaching `main` unverified.
+#
+# It is left off `push` because `develop` would then match both triggers, and
+# every commit produced two identical Rust runs. Branch protection on `main`
+# waits for each check name it sees, so a release PR blocked on a duplicate
+# 3-OS matrix that told it nothing the first had not (observed on #107).
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main", "develop" ]
 


### PR DESCRIPTION
## Problem

#106 added `develop` to **both** of rust.yml's triggers. A commit pushed directly to `develop` then matched each one, producing two identical Rust runs.

Branch protection on `main` waits for every check name it sees, so a duplicate `build-and-test (windows-latest, stable)` had to finish before a release PR could merge — even though an identical job on the same SHA had already passed. The v1.19.0 release PR (#107) sat blocked on exactly this, waiting on a second 3-OS matrix that told it nothing the first had not.

This only ever affected PRs whose **head** is `develop` — that is, release PRs. A feature-branch PR matches no `push` branch, so it only ever had the one run.

## Change

`develop` stays on `pull_request` and comes off `push`.

The `pull_request` half is the one doing the work: it gates feature PRs, which is what stops an unverified change reaching `main`. The `push` half only re-ran a commit that had already been tested as a PR. Removing it eliminates the duplication without reopening the gap #106 closed.

`main` keeps both triggers, and the `coverage` job is untouched — it gates on `if: github.ref == 'refs/heads/main'`.

## Tradeoff

A commit that reaches `develop` *without* going through a PR — a direct push, such as the `chore: release` commit — no longer gets its own CI run. That is acceptable: the release PR into `main` re-tests the identical tree before anything ships, and the tag run builds every target again.

## Verification

**Not** this PR's own check count — a feature-branch PR never showed the duplication, so its checks look the same either way. The change is confirmed by either of:

- pushing the next `chore: release` commit to `develop` produces **no** Rust run, where it previously produced a full one; and
- the next release PR (`develop` → `main`) shows each check name **once**, and is not held up by a second Windows build.

`fmt`, `clippy`, and `build-and-test` still running here confirms only that the `pull_request` trigger survived the edit intact — which is worth confirming, but is not the fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)